### PR TITLE
Add Support for Intersection Types in aelastic-types Component - resolves issue #5.

### DIFF
--- a/libraries/aelastics-types/src/common/DefinitionAPI.ts
+++ b/libraries/aelastics-types/src/common/DefinitionAPI.ts
@@ -20,6 +20,7 @@ import { LiteralType, LiteralValue } from '../simple-types/Literal';
 import { EntityReference } from '../special-types/EntityReference';
 import { ServiceError } from 'aelastics-result';
 import { TaggedUnionType } from '../complex-types/TaggedUnionType';
+import { IntersectionType } from '../complex-types/IntersectionType';
 
 export * from '../complex-types/EntityType';
 
@@ -101,6 +102,18 @@ export const taggedUnion = <P extends InterfaceDecl>(
   }
   return new TaggedUnionType(name, discr, elements, schema);
 };
+
+const getIntersectionName = <U extends Array<Any>>(elements: U): string => {
+  return `(${elements.map(baseType => baseType.name).join(' & ')})`;
+}
+
+export const intersectionOf = <P extends Array<Any>>(
+  elements: P,
+  name: string = getIntersectionName(elements),
+  schema: TypeSchema = DefaultSchema
+) => {
+  return new IntersectionType(name, elements, schema)
+}
 
 /**
  * Reference to an Entity (i.e. an object with an identifier)

--- a/libraries/aelastics-types/src/complex-types/IntersectionType.test.ts
+++ b/libraries/aelastics-types/src/complex-types/IntersectionType.test.ts
@@ -1,0 +1,122 @@
+
+import * as t from '../index'
+import { IntersectionType } from './IntersectionType';
+
+
+// example how intersection type is deefined and used 
+const Person = t.object(
+    {
+      name: t.string,
+      age: t.number,
+    },
+    'person'
+  )
+
+  const Customer = t.object(
+    {
+        customerId: t.number,
+        purchaseHistory: t.string
+    },
+    'customer'
+  )
+
+  let person1: t.TypeOf<typeof Person> = {
+    name: 'John',
+    age:35
+  }  
+  
+  let customer1: t.TypeOf<typeof Customer> = {
+    customerId: 1,
+    purchaseHistory: 'Books'
+  } 
+
+  let pc: IPersonCustomer = {name: 'John', age: 35, customerId: 1, purchaseHistory: 'Books'};
+
+  const PersonCustomer = t.intersectionOf([Person, Customer], 'personCustomer');
+
+  type IPersonCustomer = t.TypeOf<typeof PersonCustomer>
+
+
+  // test intersection type
+
+describe('IntersectionType addChild and children methods tests', () => {
+    let instance:IntersectionType<any>;
+
+    beforeEach(() => {
+        instance = new IntersectionType('TestType', [], { schema: 'TestSchema' } as any);
+    });
+
+    describe('addChild', () => {
+        it('should do nothing when both parent and child are undefined', () => {
+            const parent = undefined;
+            const child = undefined;
+            instance.addChild(parent, child, {} as any);
+            expect(parent).toBeUndefined();
+        });
+
+        it('should assign child as parent when parent is undefined', () => {
+            let parent: any = undefined;
+            const child = { key: 'value' };
+            instance.addChild(parent, child, {} as any);
+            expect(parent).toEqual(child);
+        });
+
+        it('should retain parent when child is undefined', () => {
+            const parent = { key: 'value' };
+            const child = undefined;
+            instance.addChild(parent, child, {} as any);
+            expect(parent).toEqual({ key: 'value' });
+        });
+
+        it('should merge arrays when both parent and child are arrays', () => {
+            const parent = [1, 2];
+            const child = [3, 4];
+            instance.addChild(parent, child, {} as any);
+            expect(parent).toEqual([1, 2, 3, 4]);
+        });
+
+        it('should add object properties to array when parent is an array and child is an object', () => {
+            const parent: any[] = [1, 2];
+            const child = { key: 'value' };
+            instance.addChild(parent, child, {} as any);
+            expect(parent).toEqual(expect.arrayContaining([1, 2]));
+            expect(parent).toHaveProperty('key', 'value');
+        });
+
+        it('should add parent properties to array when child is an array and parent is an object', () => {
+            let parent: any = { key: 'value' };
+            const child: any[] = [1, 2];
+            instance.addChild(parent, child, {} as any);
+            expect(child).toEqual(expect.arrayContaining([1, 2]));
+            expect(child).toHaveProperty('key', 'value');
+        });
+
+        it('should merge objects when both parent and child are objects', () => {
+            const parent = { a: 1 };
+            const child = { b: 2 };
+            instance.addChild(parent, child, {} as any);
+            expect(parent).toEqual({ a: 1, b: 2 });
+        });
+
+        it('should set parent to undefined for incompatible types', () => {
+            let parent: any = 42;
+            const child: any = true;
+            instance.addChild(parent, child, {} as any);
+            expect(parent).toBeUndefined();
+        });
+    });
+
+    describe('children', () => {
+        it('should yield elements with role "asElementOfIntersection"', () => {
+            instance = new IntersectionType('TestType', [1, 2, 3] as any, { schema: 'TestSchema' } as any);
+            const value = 123 as any;
+            const children = [...instance.children(value)];
+            expect(children).toHaveLength(3);
+            children.forEach(([v, t, info], index) => {
+                expect(v).toBe(value);
+                expect(t).toBe(instance.elements[index]);
+                expect(info).toEqual({ role: 'asElementOfIntersection' });
+            });
+        });
+    });
+});

--- a/libraries/aelastics-types/src/complex-types/IntersectionType.ts
+++ b/libraries/aelastics-types/src/complex-types/IntersectionType.ts
@@ -1,0 +1,140 @@
+/*
+ * Copyright (c) AelasticS 2024.
+ *
+ */
+
+import { Any } from '../type/Type'
+import { ComplexType } from './ComplexType'
+import { ExtraInfo } from '../type/Type'
+import { Node } from '../common/Node'
+import { TypeSchema } from '../type/TypeSchema'
+import { DtoGraphTypeOf, DtoTreeTypeOf, TypeOf } from '../common/DefinitionAPI'
+import { InstanceReference } from '../type/TypeDefinisions'
+
+
+/**
+ * Converts a union type `U` to an intersection type.
+ *
+ * This utility type takes a union type `U` and transforms it into an intersection type.
+ * It works by leveraging TypeScript's conditional types and inference capabilities.
+ *
+ * @template U - The union type to be converted to an intersection type.
+ * @returns The intersection type derived from the union type `U`.
+ *
+ * @example
+ * type A = { a: string };
+ * type B = { b: number };
+ * type C = { c: boolean };
+ * type Union = A | B | C;
+ * type Intersection = UnionToIntersection<Union>; // { a: string } & { b: number } & { c: boolean }
+ */
+type UnionToIntersection<U> = (U extends any
+  ? (k: U) => void
+  : never) extends (k: infer I) => void
+  ? I
+  : never
+
+type DtoIntersectionType<P extends Array<Any>> = {
+  ref: InstanceReference
+  intersection: { [key: string]: DtoGraphTypeOf<P[number]> } // [K in keyof P[number]]
+}
+
+// export type DtoIntersectionType2<P extends Array<Any>> = {
+//   ref: InstanceReference
+//   intersection?: Array<DtoTypeOf<P[number]>> // [K in keyof P[number]]
+// }
+
+
+export class IntersectionType<P extends Array<Any>> extends ComplexType<
+
+  UnionToIntersection<TypeOf<P[number]>>,
+  DtoIntersectionType<P>,
+  { [key: string]: DtoTreeTypeOf<P[number]> } 
+> {
+  readonly elements: P
+
+  constructor(name: string, elements: P, schema: TypeSchema) {
+    super(name, 'Intersection', schema)
+    this.elements = elements
+  }
+
+  public *children(
+    value: UnionToIntersection<TypeOf<P[number]>>
+  ): Generator<[UnionToIntersection<TypeOf<P[number]>>, Any, ExtraInfo]> {
+    for (const t of this.elements) {
+      yield [value, t, { role: 'asElementOfIntersection' /* , propName: */ }]
+    }
+  }
+
+ 
+  /**
+   * Adds a child to a parent node in a specific manner based on their types.
+   * 
+   * @param parent - The parent node which can be an array, object, or undefined.
+   * @param child - The child node which can be an array, object, or undefined.
+   * @param n - A node parameter (not used in the current implementation).
+   * 
+   * The function performs the following actions based on the types of `parent` and `child`:
+   * - If both `parent` and `child` are undefined, no action is taken.
+   * - If `parent` is undefined, `child` is assigned as the new parent.
+   * - If `child` is undefined, the parent is retained as is.
+   * - If both `parent` and `child` are arrays, they are merged.
+   * - If `parent` is an array and `child` is an object, `child`'s properties are added to the parent array.
+   * - If `child` is an array and `parent` is an object, `parent`'s properties are added to the child array and `child` becomes the new parent.
+   * - If both `parent` and `child` are objects, they are merged into the parent.
+   * - If `parent` and `child` are primitives or incompatible types, `parent` is set to undefined.
+   */
+  addChild(parent: any, child: any, n: Node): void {
+    if (parent === undefined && child === undefined) {
+        // Both are undefined, no action to take
+        return;
+    }
+
+    if (parent === undefined) {
+        // Parent is undefined, assign child as new parent
+        // This can happen because we initially set the value of intersection (i.e. parent) to be undefined
+        parent = child;
+        return;
+    }
+
+    if (child === undefined) {
+        // Child is undefined, retain parent
+        return;
+    }
+
+    if (Array.isArray(parent) && Array.isArray(child)) {
+        // Both are arrays, merge them
+        parent.push(...child);
+        return;
+    }
+
+    if (Array.isArray(parent) && typeof child === 'object' && child !== null) {
+        // Parent is array, child is object: Use Object.assign to add child's properties to parent array
+        Object.assign(parent, child);
+        return;
+    }
+
+    if (Array.isArray(child) && typeof parent === 'object' && parent !== null) {
+        // Child is array, parent is object: Add parent’s properties to child array and make child the new parent
+        Object.assign(child, parent);
+        parent = child;
+        return;
+    }
+
+    if (typeof parent === 'object' && typeof child === 'object' && parent !== null && child !== null) {
+        // Both are objects, merge them into parent
+        Object.assign(parent, child);
+        return;
+    }
+
+       // If both are primitives or incompatible types, set parent to be undefined
+    parent = undefined;
+}
+
+
+  init(n: Node): UnionToIntersection<TypeOf<P[number]>> {
+    return undefined as any;
+  }
+
+
+}

--- a/libraries/aelastics-types/src/type/Type.ts
+++ b/libraries/aelastics-types/src/type/Type.ts
@@ -18,7 +18,8 @@ export type RoleType =
   | 'asProperty'
   | 'asArrayElement'
   | 'asIdentifierPart'
-  | 'asElementOfTaggedUnion';
+  | 'asElementOfTaggedUnion'
+  | 'asElementOfIntersection';
 
 
 /**
@@ -329,3 +330,5 @@ createInstance(input?: any) {
    *
    */
 }
+export { Any };
+


### PR DESCRIPTION
**Description**:

This pull request addresses the need for supporting intersection types in the aelastic-types component. Intersection types are essential for defining types that combine multiple types into one, ensuring that an object meets all the requirements of the combined types. This enhancement will improve the flexibility and robustness of type definitions within the component.

This pull request resolves issue #5.

**Changes Made:**

Implemented support for intersection types in the aelastic-types component.

Updated relevant documentation to reflect the new feature.

Added unit tests to ensure the correct functionality of intersection types.

**Example Usage:**

typescript
export const Person = t.object(
  {
    name: t.string,
    age: t.number,
  },
  'Person'
);
export const Customer = t.object(
  {
    customerId: t.number,
    purchaseHistory: t.string,
  },
  'Customer'
);
const PersonCustomer = t.intersectionOf([Person, Customer], 'PersonCustomer');

type IPersonCustomer = t.TypeOf<typeof PersonCustomer>;

let pc: IPersonCustomer = { name: 'John', age: 35, customerId: 1, purchaseHistory: 'Books' };
Issue Reference:



**Testing:**

All existing tests pass. **But additional tests are required regarding validation and serialization.**

**Additional Notes:**
Added support for intersection types now enables resolution of issue #7 
