### PR TITLE
Update naming rules of types in aelastics types

### DIFF
--- a/libraries/aelastics-synthesis/src/test/bpm/BPM.meta.model.type.ts
+++ b/libraries/aelastics-synthesis/src/test/bpm/BPM.meta.model.type.ts
@@ -17,8 +17,8 @@ export const Process = t.subtype(Model, {
 export const Task = t.subtype(Node, {
     activity:t.string,
     worker:t.optional(Role),
-    inputs:t.arrayOf(t.link(BPM_Schema, "Document)")),
-    outputs:t.arrayOf(t.link(BPM_Schema, "Document)")),
+    inputs:t.arrayOf(t.link(BPM_Schema, "Document")),
+    outputs:t.arrayOf(t.link(BPM_Schema, "Document")),
 }, "Task", BPM_Schema);
 export const SubProcess = t.subtype(Task, {
     process:Process

--- a/libraries/aelastics-types/src/common/DefinitionAPI.link.test.ts
+++ b/libraries/aelastics-types/src/common/DefinitionAPI.link.test.ts
@@ -1,0 +1,58 @@
+import { TypeSchema, LinkType, link, Type, object } from '../index';
+import { ServiceError } from 'aelastics-result';
+
+describe('link function tests', () => {
+    let schema: TypeSchema;
+    let owner: TypeSchema;
+
+    beforeEach(() => {
+        schema = new TypeSchema('TestSchema');
+        owner = new TypeSchema('OwnerSchema');
+    });
+
+    test('should create a new LinkType when it does not exist', () => {
+        const path = 'some/path';
+        const name = 'TestLink';
+        const result = link(schema, path, name, owner);
+
+        expect(result).toBeInstanceOf(LinkType);
+        expect(result.name).toBe(name);
+        expect(result.LinkSchema).toBe(schema);
+        expect(result.path).toBe(path);
+        expect(result.ownerSchema).toBe(owner);
+    });
+
+    test('should create a new LinkType with generated name when name is not provided', () => {
+        const path = 'some/path';
+        const result = link(schema, path);
+
+        expect(result).toBeInstanceOf(LinkType);
+        expect(result.name).toBe(Type.sanitizeName(`LinkTo_${schema.absolutePathName}/${path}`));
+        expect(result.LinkSchema).toBe(schema);
+        expect(result.path).toBe(path);
+        expect(result.ownerSchema).toBe(schema);
+    });
+
+    test('should return existing LinkType if it matches the absolute path name', () => {
+        const path = 'some/path';
+        const name = 'TestLink';
+        const existingLink = link(schema, path, name, owner);
+        const result = link(schema, path, name, owner);
+        expect(result).toBe(existingLink);
+    });
+
+    test('should throw error if existing LinkType has different absolute path name', () => {
+        const path = 'some/path';
+        const name = 'TestLink';
+        const existingLink = link(schema, 'different/path', name, owner);
+        expect(() => link(schema, path, name, owner)).toThrow(ServiceError);
+    });
+
+    test('should throw error if existing type with the same name is not a LinkType', () => {
+        const path = 'some/path';
+        const name = 'TestLink';
+        const existingType = object({}, name, schema);
+
+        expect(() => link(schema, path, name, schema)).toThrow(ServiceError);
+    });
+});

--- a/libraries/aelastics-types/src/common/DefinitionAPI.ts
+++ b/libraries/aelastics-types/src/common/DefinitionAPI.ts
@@ -191,7 +191,7 @@ export const literal = <V extends LiteralValue>(
   value: V,
   schema: TypeSchema = DefaultSchema
 ): LiteralType<V> => {
-  const name: string = schema.generateName(value.toString()); // JSON.stringify(value)
+  const name: string = schema.generateName(`Literal_${value.toString()}`); // JSON.stringify(value)
   return new LiteralType<V>(name, 'Literal', schema, value);
 };
 

--- a/libraries/aelastics-types/src/common/DefinitionAPI.ts
+++ b/libraries/aelastics-types/src/common/DefinitionAPI.ts
@@ -139,8 +139,7 @@ export const entityRef = <T extends ObjectType<any, readonly string[]>>(
   t: T,
   name?: string,
   schema: TypeSchema = DefaultSchema
-) => 
-{
+) => {
   if (name === undefined || name === '') name = schema.generateName(`referenceTo${t.name}}>`);
   let obj = new EntityReference<T>(name, t, schema);
   return obj;
@@ -232,19 +231,22 @@ export const link = (
   schema: TypeSchema,
   path: string,
   name?: string,
-  owner: TypeSchema = DefaultSchema
+  owner: TypeSchema = schema
 ) => {
   const absolutePathName = schema.absolutePathName + '/' + path;
+  const getAbsolutePathName = (l: LinkType) => `${l.LinkSchema.absolutePathName}/${l.path}`;
 
-  if (name == undefined) name = `LinkTo_${absolutePathName}`;
+  if (name == undefined) 
+    name = `LinkTo_${absolutePathName}`;
+  name = Type.sanitizeName(name);
 
   const linkType = owner.getType(name);
 
-  if (linkType instanceof LinkType && linkType.fullPathName === absolutePathName) {
+  if (linkType instanceof LinkType  && getAbsolutePathName(linkType) === absolutePathName) {
     return linkType;
   }
 
-  if (linkType instanceof LinkType && linkType.fullPathName !== absolutePathName) {
+  if (linkType instanceof LinkType && getAbsolutePathName(linkType) !== absolutePathName) {
     throw new ServiceError('ValidationError', `LinkType ${name} already exists in schema ${owner.name} pointing to different concept (${linkType.fullPathName})`);
   }
 

--- a/libraries/aelastics-types/src/type/Type.ts
+++ b/libraries/aelastics-types/src/type/Type.ts
@@ -72,12 +72,15 @@ export abstract class Type<V, G, T> {
 
 /**
    * Constructs a new Type instance.
-   * @param name The name of the type, unique within its schema.
+   * @param name The name of the type, unique within its schema. See below naming rules. 
    * @param typeCategory The category of the type, which helps in defining its behavior and properties.
    * @param schema The schema to which this type belongs.
    * @param validator Optional validator to apply to values of this type.
    */
 constructor(name: string, typeCategory: TypeCategory, schema: TypeSchema, validator?: Validator<V>) {
+  if (!this.isValidName(name)) {
+    throw new Error(`Invalid name: "${name}". Please follow the naming rules.`);
+}
   this.name = name;
   this.ownerSchema = schema;
   this.typeCategory = typeCategory;
@@ -91,6 +94,25 @@ constructor(name: string, typeCategory: TypeCategory, schema: TypeSchema, valida
     schema.addType(this);
   }
 }
+
+
+   /**
+ * Validates a name according to the defined naming rules.
+ * 
+ * Rules:
+ * 1. A name must start with an underscore (`_`), a letter, or a dollar sign (`$`).
+ * 2. It must be followed by alphanumeric characters, with spaces allowed between words.
+ * 3. Underscores (`_`), hyphens (`-`), dollar signs (`$`), and digits are allowed but cannot be standalone.
+ * 4. Two or more consecutive spaces are not allowed.
+ * 5. The `/` character is not allowed.
+ * 
+ * @param name - The name to validate.
+ * @returns True if the name is valid, otherwise false.
+ */
+    private isValidName(name: string): boolean {
+      const regex = /^[_a-zA-Z\$][a-zA-Z0-9_\$-]*(?: [a-zA-Z0-9_\$-]+)*$/;
+      return regex.test(name);
+  }
 
 /**
  * Retrieves the path from the root schema, if applicable.

--- a/libraries/aelastics-types/src/type/Type.ts
+++ b/libraries/aelastics-types/src/type/Type.ts
@@ -78,7 +78,7 @@ export abstract class Type<V, G, T> {
      * @param validator Optional validator to apply to values of this type.
      */
   constructor(name: string, typeCategory: TypeCategory, schema: TypeSchema, validator?: Validator<V>) {
-    const sanitizedName = this.sanitizeName(name);
+    const sanitizedName = Type.sanitizeName(name);
     if (!this.isValidName(sanitizedName)) {
       throw new Error(`Invalid name: "${sanitizedName}". Please follow the naming rules.`);
     }
@@ -115,13 +115,13 @@ export abstract class Type<V, G, T> {
     return regex.test(name);
   }
 
-  // Private method to sanitize names
-  private sanitizeName(name: string): string {
-    return name
+// Public static method to sanitize names
+public static sanitizeName(name: string): string {
+  return name
       .replace(/\//g, '_')            // Replace "/" with "_"
       .trim()                         // Trim spaces from the beginning and end
       .replace(/\s{2,}/g, ' ');       // Replace two or more consecutive spaces with a single space
-  }
+}
 
   /**
    * Retrieves the path from the root schema, if applicable.
@@ -150,7 +150,7 @@ export abstract class Type<V, G, T> {
    */
   public derive(name?: string, schema: TypeSchema = DefaultSchema): this {
     if (name === undefined || name === '') {
-      name = schema.generateName(`derived from ${this.sanitizeName(this.fullPathName)}`);
+      name = schema.generateName(`derived from ${Type.sanitizeName(this.fullPathName)}`);
     }
     const derived = new (this.constructor as any)(name, this.typeCategory, schema);
     derived.derivedFrom = this;

--- a/libraries/aelastics-types/src/type/Type.ts
+++ b/libraries/aelastics-types/src/type/Type.ts
@@ -70,268 +70,277 @@ export abstract class Type<V, G, T> {
   // Array of validators checking constraints on values of this type
   private validators: Validator<V>[] = [];
 
-/**
-   * Constructs a new Type instance.
-   * @param name The name of the type, unique within its schema. See below naming rules. 
-   * @param typeCategory The category of the type, which helps in defining its behavior and properties.
-   * @param schema The schema to which this type belongs.
-   * @param validator Optional validator to apply to values of this type.
-   */
-constructor(name: string, typeCategory: TypeCategory, schema: TypeSchema, validator?: Validator<V>) {
-  if (!this.isValidName(name)) {
-    throw new Error(`Invalid name: "${name}". Please follow the naming rules.`);
-}
-  this.name = name;
-  this.ownerSchema = schema;
-  this.typeCategory = typeCategory;
-  if (validator) {
-    this.addValidator(validator);
-  }
-  if (schema === System) {
-    this.isSystemType = true;
-    System._types.set(this.name, this);
-  } else {
-    schema.addType(this);
-  }
-}
-
-
-   /**
- * Validates a name according to the defined naming rules.
- * 
- * Rules:
- * 1. A name must start with an underscore (`_`), a letter, or a dollar sign (`$`).
- * 2. It must be followed by alphanumeric characters, with spaces allowed between words.
- * 3. Underscores (`_`), hyphens (`-`), dollar signs (`$`), and digits are allowed but cannot be standalone.
- * 4. Two or more consecutive spaces are not allowed.
- * 5. The `/` character is not allowed.
- * 
- * @param name - The name to validate.
- * @returns True if the name is valid, otherwise false.
- */
-    private isValidName(name: string): boolean {
-      const regex = /^[_a-zA-Z\$][a-zA-Z0-9_\$-]*(?: [a-zA-Z0-9_\$-]+)*$/;
-      return regex.test(name);
-  }
-
-/**
- * Retrieves the path from the root schema, if applicable.
- */
-private get pathFromRoot(): string {
-  return this.isSystemType ? '' : `${this.ownerSchema.path}/${this.ownerSchema.name}`;
-}
-
-/**
- * Returns the full path name of the type, including its path from the root schema.
- */
-public get fullPathName(): string {
-  return `${this.pathFromRoot}/${this.name}`;
-}
-
-/**
- * Abstract method to determine if the type is simple.
- */
-abstract isSimple(): boolean;
-
-/**
- * Derives a new type from this type.
- * @param name The name of the new derived type, optional.
- * @param schema The schema for the new type, defaults to DefaultSchema if not provided.
- * @returns A new instance of the derived type.
- */
-public derive(name?: string, schema: TypeSchema = DefaultSchema): this {
-  if (name === undefined || name === '') {
-    name = schema.generateName(`derived from ${this.fullPathName}`);
-  }
-  const derived = new (this.constructor as any)(name, this.typeCategory, schema);
-  derived.derivedFrom = this;
-  return derived;
-}
-/**
-   * Checks if this type is of or derived from another type.
-   * @param t The type to check against.
-   * @returns true if this type is or derives from the given type.
-   */
-public isOfType(t: Type<any, any, any>): boolean {
-  return t === this || (this.derivedFrom?.isOfType(t))?true:false
-}
-
-/**
- * Adds a validator to this type.
- * @param validator The validator to add.
- * @returns this instance for chaining.
- */
-public addValidator(validator: Validator<V>): this {
-  if (this.isSystemType) {
-    throw new ServiceError(
-      'OperationNotAllowed',
-      `Type '${this.name}' is a system type. New constraints are not allowed! Define a derived type instead.`
-    );
-  }
-  this.validators.push(validator);
-  return this;
-}
-
-/**
- * Checks the validators for the given value, accumulating errors.
- * @param value The value to check.
- * @returns A ServiceResult indicating success or failure with detailed errors.
- */
-public checkValidators(value: any): ServiceResult<boolean> {
-  const errs: ServiceError[] = [];
-  let hasError: boolean = false;
-  let currentType: any = this;
-  while (currentType) {
-    hasError = hasError || this.checkOneLevel(currentType, value, errs);
-    currentType = currentType.derivedFrom;
-  }
-  return hasError ? failures(errs) : success(true);
-}
-
-/**
- * Helper method to check validators at one level.
- * @internal
- * @param currentType The current type context.
- * @param value The value to validate.
- * @param errs Array to accumulate errors.
- * @returns true if an error was found.
- */
-private checkOneLevel(currentType: Any, value: any, errs: ServiceError[]): boolean {
-  let hasError: boolean = false;
-  for (const { predicate, message } of currentType.validators) {
-    if (!predicate(value)) {
-      errs.unshift(new ServiceError('ValidationError', message(value, this.name), this.name));
-      hasError = true;
+  /**
+     * Constructs a new Type instance.
+     * @param name The name of the type, unique within its schema. See below naming rules. 
+     * @param typeCategory The category of the type, which helps in defining its behavior and properties.
+     * @param schema The schema to which this type belongs.
+     * @param validator Optional validator to apply to values of this type.
+     */
+  constructor(name: string, typeCategory: TypeCategory, schema: TypeSchema, validator?: Validator<V>) {
+    const sanitizedName = this.sanitizeName(name);
+    if (!this.isValidName(sanitizedName)) {
+      throw new Error(`Invalid name: "${sanitizedName}". Please follow the naming rules.`);
+    }
+    this.name = sanitizedName;
+    this.ownerSchema = schema;
+    this.typeCategory = typeCategory;
+    if (validator) {
+      this.addValidator(validator);
+    }
+    if (schema === System) {
+      this.isSystemType = true;
+      System._types.set(this.name, this);
+    } else {
+      schema.addType(this);
     }
   }
-  return hasError;
-}
-/**
- * Transforms the input data using the specified processor.
- * @param t The processor to use for transformation.
- * @param input The input data or node.
- * @param initObj The initial object to start with.
- * @param resetAcc Whether to reset the accumulator.
- * @param typeLevel Whether the transformation should consider type level specifics.
- * @returns The transformed data.
- */
-transduce<A>(t: IProcessor, input: any | Node, initObj?: A, resetAcc?: boolean, typeLevel:boolean=false): A {
-  let [res, _] = this.doTransformation(t, input, initObj, resetAcc, typeLevel);
-  return res;
-}
 
-/**
- * Abstract method to handle the transformation process.
- * Must be implemented by subclasses to define specific transformation behaviors.
- * @param t The processor to use for transformation.
- * @param input The input data or node.
- * @param initObj The initial object to start with.
- * @param resetAcc Whether to reset the accumulator.
- * @param typeLevel Whether the transformation should consider type level specifics.
- * @returns A tuple containing the transformed data and the next action.
- */
-abstract doTransformation<A>(
-  t: IProcessor,
-  input: any | Node,
-  initObj?: A,
-  resetAcc?: boolean,
-  typeLevel?:boolean
-): [A, WhatToDo];
 
-/**
- * Abstract method to iterate over children of a given value within a node.
- * Must be implemented by subclasses to handle specific child iteration logic.
- * @param i The instance whose children to iterate over.
- * @param n The node context for the iteration.
- * @returns A generator yielding tuples of child values, their types, and extra information.
- */
-abstract children(i: V, n: Node): Generator<[V, Any, ExtraInfo]>;
+  /**
+* Validates a name according to the defined naming rules.
+* 
+* Rules:
+* 1. A name must start with an underscore (`_`), a letter, or a dollar sign (`$`).
+* 2. It must be followed by alphanumeric characters, with spaces allowed between words.
+* 3. Underscores (`_`), hyphens (`-`), dollar signs (`$`), and digits are allowed but cannot be standalone.
+* 4. Two or more consecutive spaces are not allowed.
+* 5. The `/` character is not allowed.
+* 
+* @param name - The name to validate.
+* @returns True if the name is valid, otherwise false.
+*/
+  private isValidName(name: string): boolean {
+    const regex = /^[_a-zA-Z\$][a-zA-Z0-9_\$-]*(?: [a-zA-Z0-9_\$-]+)*$/;
+    return regex.test(name);
+  }
 
-/**
- * Abstract method to initialize and create an empty instance of the type.
- * Must be implemented by subclasses to define how new instances are created.
- * @param n The node context for the initialization.
- * @returns An initialized, empty instance of the type.
- */
-abstract init(n: Node): V;
+  // Private method to sanitize names
+  private sanitizeName(name: string): string {
+    return name
+      .replace(/\//g, '_')            // Replace "/" with "_"
+      .trim()                         // Trim spaces from the beginning and end
+      .replace(/\s{2,}/g, ' ');       // Replace two or more consecutive spaces with a single space
+  }
 
-/**
- * Abstract method to add a child to a parent object within the context of a node.
- * Must be implemented by subclasses to define how children are added to parent instances.
- * @param parent The parent object to add a child to.
- * @param child The child object to add.
- * @param n The node context for adding the child.
- */
-abstract addChild(parent: any, child: any, n: Node): void;
+  /**
+   * Retrieves the path from the root schema, if applicable.
+   */
+  private get pathFromRoot(): string {
+    return this.isSystemType ? '' : `${this.ownerSchema.path}/${this.ownerSchema.name}`;
+  }
 
-/**
- * Validates the input value and reports any errors encountered.
- * @param input The input value to validate.
- * @returns A tuple indicating whether validation passed and any error object associated with failures.
- */
-validateAndReport(input: V): [boolean, ErrorObject] {
-  let res: any;
-  try {
-    const tr = transducer()
-      .recurse('makeItem')
-      .validate()
-      .filter((item, currNode) => item && item['@hasErrors'])
-      .doFinally(naturalReducer());
-    res = this.transduce(tr, input);
-    if (res && res['@hasErrors']) {
+  /**
+   * Returns the full path name of the type, including its path from the root schema.
+   */
+  public get fullPathName(): string {
+    return `${this.pathFromRoot}/${this.name}`;
+  }
+
+  /**
+   * Abstract method to determine if the type is simple.
+   */
+  abstract isSimple(): boolean;
+
+  /**
+   * Derives a new type from this type.
+   * @param name The name of the new derived type, optional.
+   * @param schema The schema for the new type, defaults to DefaultSchema if not provided.
+   * @returns A new instance of the derived type.
+   */
+  public derive(name?: string, schema: TypeSchema = DefaultSchema): this {
+    if (name === undefined || name === '') {
+      name = schema.generateName(`derived from ${this.sanitizeName(this.fullPathName)}`);
+    }
+    const derived = new (this.constructor as any)(name, this.typeCategory, schema);
+    derived.derivedFrom = this;
+    return derived;
+  }
+  /**
+     * Checks if this type is of or derived from another type.
+     * @param t The type to check against.
+     * @returns true if this type is or derives from the given type.
+     */
+  public isOfType(t: Type<any, any, any>): boolean {
+    return t === this || (this.derivedFrom?.isOfType(t)) ? true : false
+  }
+
+  /**
+   * Adds a validator to this type.
+   * @param validator The validator to add.
+   * @returns this instance for chaining.
+   */
+  public addValidator(validator: Validator<V>): this {
+    if (this.isSystemType) {
+      throw new ServiceError(
+        'OperationNotAllowed',
+        `Type '${this.name}' is a system type. New constraints are not allowed! Define a derived type instead.`
+      );
+    }
+    this.validators.push(validator);
+    return this;
+  }
+
+  /**
+   * Checks the validators for the given value, accumulating errors.
+   * @param value The value to check.
+   * @returns A ServiceResult indicating success or failure with detailed errors.
+   */
+  public checkValidators(value: any): ServiceResult<boolean> {
+    const errs: ServiceError[] = [];
+    let hasError: boolean = false;
+    let currentType: any = this;
+    while (currentType) {
+      hasError = hasError || this.checkOneLevel(currentType, value, errs);
+      currentType = currentType.derivedFrom;
+    }
+    return hasError ? failures(errs) : success(true);
+  }
+
+  /**
+   * Helper method to check validators at one level.
+   * @internal
+   * @param currentType The current type context.
+   * @param value The value to validate.
+   * @param errs Array to accumulate errors.
+   * @returns true if an error was found.
+   */
+  private checkOneLevel(currentType: Any, value: any, errs: ServiceError[]): boolean {
+    let hasError: boolean = false;
+    for (const { predicate, message } of currentType.validators) {
+      if (!predicate(value)) {
+        errs.unshift(new ServiceError('ValidationError', message(value, this.name), this.name));
+        hasError = true;
+      }
+    }
+    return hasError;
+  }
+  /**
+   * Transforms the input data using the specified processor.
+   * @param t The processor to use for transformation.
+   * @param input The input data or node.
+   * @param initObj The initial object to start with.
+   * @param resetAcc Whether to reset the accumulator.
+   * @param typeLevel Whether the transformation should consider type level specifics.
+   * @returns The transformed data.
+   */
+  transduce<A>(t: IProcessor, input: any | Node, initObj?: A, resetAcc?: boolean, typeLevel: boolean = false): A {
+    let [res, _] = this.doTransformation(t, input, initObj, resetAcc, typeLevel);
+    return res;
+  }
+
+  /**
+   * Abstract method to handle the transformation process.
+   * Must be implemented by subclasses to define specific transformation behaviors.
+   * @param t The processor to use for transformation.
+   * @param input The input data or node.
+   * @param initObj The initial object to start with.
+   * @param resetAcc Whether to reset the accumulator.
+   * @param typeLevel Whether the transformation should consider type level specifics.
+   * @returns A tuple containing the transformed data and the next action.
+   */
+  abstract doTransformation<A>(
+    t: IProcessor,
+    input: any | Node,
+    initObj?: A,
+    resetAcc?: boolean,
+    typeLevel?: boolean
+  ): [A, WhatToDo];
+
+  /**
+   * Abstract method to iterate over children of a given value within a node.
+   * Must be implemented by subclasses to handle specific child iteration logic.
+   * @param i The instance whose children to iterate over.
+   * @param n The node context for the iteration.
+   * @returns A generator yielding tuples of child values, their types, and extra information.
+   */
+  abstract children(i: V, n: Node): Generator<[V, Any, ExtraInfo]>;
+
+  /**
+   * Abstract method to initialize and create an empty instance of the type.
+   * Must be implemented by subclasses to define how new instances are created.
+   * @param n The node context for the initialization.
+   * @returns An initialized, empty instance of the type.
+   */
+  abstract init(n: Node): V;
+
+  /**
+   * Abstract method to add a child to a parent object within the context of a node.
+   * Must be implemented by subclasses to define how children are added to parent instances.
+   * @param parent The parent object to add a child to.
+   * @param child The child object to add.
+   * @param n The node context for adding the child.
+   */
+  abstract addChild(parent: any, child: any, n: Node): void;
+
+  /**
+   * Validates the input value and reports any errors encountered.
+   * @param input The input value to validate.
+   * @returns A tuple indicating whether validation passed and any error object associated with failures.
+   */
+  validateAndReport(input: V): [boolean, ErrorObject] {
+    let res: any;
+    try {
+      const tr = transducer()
+        .recurse('makeItem')
+        .validate()
+        .filter((item, currNode) => item && item['@hasErrors'])
+        .doFinally(naturalReducer());
+      res = this.transduce(tr, input);
+      if (res && res['@hasErrors']) {
+        return [false, res];
+      }
+      return [true, res];
+    } catch (e) {
+      if (res === undefined) {
+        res = { '@hasErrors': true, '@errors': [(e as any)["message"]] };
+      }
       return [false, res];
     }
-    return [true, res];
-  } catch (e) {
-    if (res === undefined) {
-      res = { '@hasErrors': true, '@errors': [(e as any)["message"]] };
-    }
-    return [false, res];
   }
-}
 
-/**
- * Simplifies the process of validating a value, directly returning a service result indicating success or failure.
- * @param input The input value to validate.
- * @returns A ServiceResult indicating whether the input is valid, along with detailed error information if not.
- */
-validate(input: V): ServiceResult<boolean> {
-  let [res, errorObj] = this.validateAndReport(input);
-  if (res) {
-    return success(res);
-  } else return failures(errorObj['@errors'] as ServiceError[]);
-}
+  /**
+   * Simplifies the process of validating a value, directly returning a service result indicating success or failure.
+   * @param input The input value to validate.
+   * @returns A ServiceResult indicating whether the input is valid, along with detailed error information if not.
+   */
+  validate(input: V): ServiceResult<boolean> {
+    let [res, errorObj] = this.validateAndReport(input);
+    if (res) {
+      return success(res);
+    } else return failures(errorObj['@errors'] as ServiceError[]);
+  }
 
-/**
- * Converts an input object of natural value type into a graph-formatted Data Transfer Object.
- * @param input The input object to convert.
- * @returns The converted graph DTO.
- */
-toDtoGraph(input: V): G {
-  const tr = transducer().recurse('makeItem').toDtoGraph().doFinally(identityReducer());
-  return this.transduce<G>(tr, input);
-}
+  /**
+   * Converts an input object of natural value type into a graph-formatted Data Transfer Object.
+   * @param input The input object to convert.
+   * @returns The converted graph DTO.
+   */
+  toDtoGraph(input: V): G {
+    const tr = transducer().recurse('makeItem').toDtoGraph().doFinally(identityReducer());
+    return this.transduce<G>(tr, input);
+  }
 
-/**
- * Converts an input graph-formatted Data Transfer Object back into the natural value type.
- * @param input The graph DTO to convert.
- * @returns The converted natural value type.
- */
-fromDtoGraph(input: G): V {
-  let tr = transducer().recurse('makeItem').fromDtoGraph().doFinally(identityReducer());
-  return this.transduce<V>(tr, input);
-}
+  /**
+   * Converts an input graph-formatted Data Transfer Object back into the natural value type.
+   * @param input The graph DTO to convert.
+   * @returns The converted natural value type.
+   */
+  fromDtoGraph(input: G): V {
+    let tr = transducer().recurse('makeItem').fromDtoGraph().doFinally(identityReducer());
+    return this.transduce<V>(tr, input);
+  }
 
-/**
- * Creates a new instance of the type, potentially using a provided input as the basis.
- * @param input Optional input to use as the basis for the new instance.
- * @returns The newly created instance.
- */
-createInstance(input?: any) {
-  let tr = transducer().recurse('makeItem').newInstance(input).doFinally(naturalReducer());
-  let obj = this.transduce(tr, undefined);
-  return obj;
-}
+  /**
+   * Creates a new instance of the type, potentially using a provided input as the basis.
+   * @param input Optional input to use as the basis for the new instance.
+   * @returns The newly created instance.
+   */
+  createInstance(input?: any) {
+    let tr = transducer().recurse('makeItem').newInstance(input).doFinally(naturalReducer());
+    let obj = this.transduce(tr, undefined);
+    return obj;
+  }
 
   /** ToDo: Reduce
    *  - reduceType, reduceBoth

--- a/libraries/examples/src/bpm/BPM.meta.model.type.ts
+++ b/libraries/examples/src/bpm/BPM.meta.model.type.ts
@@ -17,8 +17,8 @@ export const Process = t.subtype(Model, {
 export const Task = t.subtype(Node, {
     activity:t.string,
     worker:t.optional(Role),
-    inputs:t.arrayOf(t.link(BPM_Schema, "Document)")),
-    outputs:t.arrayOf(t.link(BPM_Schema, "Document)")),
+    inputs:t.arrayOf(t.link(BPM_Schema, "Document")),
+    outputs:t.arrayOf(t.link(BPM_Schema, "Document")),
 }, "Task", BPM_Schema);
 export const SubProcess = t.subtype(Task, {
     process:Process

--- a/libraries/generic-metamodel/src/models.type.ts
+++ b/libraries/generic-metamodel/src/models.type.ts
@@ -19,7 +19,7 @@ export const ModelElement = t.subtype(RepositoryObject,{
     // label is logically same as name, but can it be consisting of several words (and shown in multiple lines)
     // label is shown and entered in UI; name is computed from label by removing all extra spaces and newlines
     label: t.string,
-    content: t.string.derive('65535').maxLength(65535),
+    content: t.string.derive('max_65535').maxLength(65535),
     parentModel: t.optional(t.link(ModelSchema, 'Model')), // to be defined as Ref
     namespace: t.optional(t.link(ModelSchema, 'Namespace')) // to be defined as Ref
 },  "ModelElement", ModelSchema);


### PR DESCRIPTION
## **Description**

This PR introduces the following key updates and improvements:

1. **Name Sanitization**:
   - Added a method to sanitize object names to ensure compliance with the naming rules.
   - Replaces `/` with `_`, trims leading and trailing spaces, and normalizes consecutive spaces to a single space.
   - Exposed the sanitization method as a public static method in the `Type` class for use across other classes.

2. **Validation Enhancements**:
   - Updated the name validation logic to enforce the latest naming rules:
     - Names must start with `_`, a letter, or `$`.
     - Names may include alphanumeric characters, `_`, `$`, and `-` but cannot have consecutive spaces or standalone characters  `_`, `$`, and `-`.

3. **Fixes for Literal Naming Issues**:
   - Adjusted names of literals across the codebase to conform to the updated rules.
   - Updated related tests and added new test cases to cover edge cases.

---

## **Key Changes**
- **Type Class**:
  - Introduced a public static method `sanitizeName()` for sanitization.
  - Enhanced the constructor to automatically sanitize and validate names.
- **Tests**:
  - Added comprehensive unit tests to ensure the sanitization and validation logic works as expected.
  - Fixed failing tests in the `aelastics-store` package caused by previous naming issues.
- **Other Packages**:
  - Updated literal names in dependent packages to resolve conflicts with the new rules.

---

## **Motivation**
The previous implementation allowed invalid names that conflicted with namespace paths and caused issues in dependent packages. This PR resolves those problems by standardizing names and providing a robust sanitization process, ensuring consistency and maintainability.
