### PR TITLE
feat: Add support for extra argument in all observable handlers

### DIFF
--- a/libraries/aelastics-store/.gitignore
+++ b/libraries/aelastics-store/.gitignore
@@ -8,6 +8,4 @@ dist
 compiled
 .awcache
 .rpt2_cache
-docs
 lib
-

--- a/libraries/aelastics-store/src/common/observable-doc/docs/advanced/extending-handlers.md
+++ b/libraries/aelastics-store/src/common/observable-doc/docs/advanced/extending-handlers.md
@@ -1,0 +1,122 @@
+# Extending Handlers
+
+## Introduction
+
+AelasticS-Observables provides built-in handlers for managing observability of objects, arrays, maps, and sets. However, you can **extend handlers** to customize behavior and apply additional logic, such as **logging, validation, access control, or state tracking**.
+
+## Customizing Handlers
+
+### **1️⃣ Adding Logging to Observables**
+You can wrap existing handlers with custom logic to log changes.
+
+```typescript
+import { createObservableObject } from 'aelastics-observables';
+
+const handlers = {
+    set: (target, key, value) => {
+        console.log(`Property '${String(key)}' changed to ${value}`);
+        return true; // Allow mutation
+    },
+    delete: (target, key) => {
+        console.log(`Property '${String(key)}' deleted`);
+        return true;
+    }
+};
+
+const obj = createObservableObject({ name: "Alice" }, handlers);
+obj.name = "Bob"; // Logs: "Property 'name' changed to Bob"
+delete obj.name; // Logs: "Property 'name' deleted"
+```
+
+### **2️⃣ Adding Validation to Objects**
+Prevent modifications unless certain conditions are met.
+
+```typescript
+const handlers = {
+    set: (target, key, value) => {
+        if (key === "age" && value < 0) {
+            console.warn("Age cannot be negative!");
+            return false; // Block mutation
+        }
+        return true;
+    }
+};
+
+const obj = createObservableObject({ age: 25 }, handlers);
+obj.age = -5; // Logs: "Age cannot be negative!" and blocks the update
+```
+
+### **3️⃣ Role-Based Access Control (RBAC)**
+Allow property modification only for specific users.
+
+```typescript
+const handlers = {
+    set: (target, key, value, extra) => {
+        if (extra?.role !== "admin") {
+            console.warn("Permission denied!");
+            return false;
+        }
+        return true;
+    }
+};
+
+const obj = createObservableObject({ setting: "default" }, handlers, true, { role: "guest" });
+obj.setting = "new"; // Logs: "Permission denied!" and blocks mutation
+```
+
+### **4️⃣ Intercepting Methods in Objects**
+Modify or block method execution.
+
+```typescript
+const handlers = {
+    method: (target, key, args) => {
+        console.log(`Method '${String(key)}' was called with arguments:`, args);
+        return true;
+    }
+};
+
+const obj = createObservableObject({
+    greet: (name) => `Hello, ${name}!`
+}, handlers);
+
+console.log(obj.greet("Alice")); // Logs: "Method 'greet' was called with arguments: ['Alice']"
+```
+
+## Extending Handlers for Collections
+
+### **Extending Array Handlers**
+```typescript
+const handlers = {
+    push: (target, items) => {
+        console.log(`Adding ${items.length} items to the array.`);
+        return true;
+    }
+};
+
+const arr = createObservableArray([], handlers);
+arr.push(10, 20); // Logs: "Adding 2 items to the array."
+```
+
+### **Extending Map Handlers**
+```typescript
+const handlers = {
+    set: (target, key, value) => {
+        console.log(`Map key '${key}' set to '${value}'`);
+        return true;
+    }
+};
+
+const map = createObservableMap(new Map(), handlers);
+map.set("a", 100); // Logs: "Map key 'a' set to '100'"
+```
+
+## Summary
+
+- Handlers allow **customization of observables**.
+- Can be used for **logging, validation, security, and method interception**.
+- Extend behavior for **objects, arrays, maps, and sets**.
+
+## Next Steps
+
+➡ **[Performance Optimizations](./performance.md)** – Learn best practices for improving efficiency.  
+➡ **[Integration](./integration.md)** – Using observables with frameworks like React and Vue.  

--- a/libraries/aelastics-store/src/common/observable-doc/docs/advanced/integration.md
+++ b/libraries/aelastics-store/src/common/observable-doc/docs/advanced/integration.md
@@ -1,0 +1,152 @@
+# Integration with Frameworks
+
+## Introduction
+
+AelasticS-Observables can be easily integrated with modern frontend frameworks like **React**, **Vue**, and **Svelte**. This guide covers best practices for using observables efficiently in UI-driven applications.
+
+## Using AelasticS-Observables with React
+
+React relies on **state immutability**, so when working with observables, you need to ensure **React updates properly**.
+
+### **1️⃣ Using Observables in React State**
+
+Since observables update properties directly, React **might not re-render automatically**. To force updates, you can use the `useState` or `useReducer` hook.
+
+```typescript
+import React, { useState } from "react";
+import { createObservableObject } from "aelastics-observables";
+
+const Counter = () => {
+    const [, forceUpdate] = useState(0);
+
+    const counter = createObservableObject({ count: 0 }, {
+        set: () => {
+            forceUpdate(prev => prev + 1); // Forces React to re-render
+            return true;
+        }
+    });
+
+    return (
+        <div>
+            <p>Count: {counter.count}</p>
+            <button onClick={() => counter.count++}>Increment</button>
+        </div>
+    );
+};
+
+export default Counter;
+```
+
+### **2️⃣ Using Observables with React Context**
+
+You can store observable objects inside a **React Context** to provide **global state management**.
+
+```typescript
+import React, { createContext, useContext } from "react";
+import { createObservableObject } from "aelastics-observables";
+
+const CounterContext = createContext(null);
+
+const CounterProvider = ({ children }) => {
+    const counter = createObservableObject({ count: 0 }, {});
+    return <CounterContext.Provider value={counter}>{children}</CounterContext.Provider>;
+};
+
+const Counter = () => {
+    const counter = useContext(CounterContext);
+    return (
+        <div>
+            <p>Count: {counter.count}</p>
+            <button onClick={() => counter.count++}>Increment</button>
+        </div>
+    );
+};
+
+export default function App() {
+    return (
+        <CounterProvider>
+            <Counter />
+        </CounterProvider>
+    );
+}
+```
+
+---
+
+## Using AelasticS-Observables with Vue
+
+Vue provides **reactive state management** with `ref` and `reactive()`. **AelasticS-Observables** can be integrated as a replacement.
+
+### **1️⃣ Creating a Reactive Object in Vue**
+
+```typescript
+import { createObservableObject } from "aelastics-observables";
+import { ref } from "vue";
+
+export default {
+    setup() {
+        const state = createObservableObject({ count: 0 }, {});
+        return { state };
+    }
+};
+```
+
+### **2️⃣ Using Observables in Vue Components**
+
+```vue
+<template>
+  <div>
+    <p>Count: {{ state.count }}</p>
+    <button @click="state.count++">Increment</button>
+  </div>
+</template>
+
+<script>
+import { createObservableObject } from "aelastics-observables";
+
+export default {
+  setup() {
+    const state = createObservableObject({ count: 0 }, {});
+    return { state };
+  }
+};
+</script>
+```
+
+---
+
+## Using AelasticS-Observables with Svelte
+
+Svelte has a built-in **reactive store system**, but you can also use AelasticS-Observables.
+
+### **1️⃣ Creating an Observable Store**
+
+```typescript
+import { createObservableObject } from "aelastics-observables";
+
+export const state = createObservableObject({ count: 0 }, {});
+```
+
+### **2️⃣ Using the Observable in a Svelte Component**
+
+```svelte
+<script>
+  import { state } from "./store.js";
+</script>
+
+<p>Count: {state.count}</p>
+<button on:click={() => state.count++}>Increment</button>
+```
+
+---
+
+## Summary
+
+✔ **React** → Use `useState` or Context API to trigger re-renders.  
+✔ **Vue** → Use inside `setup()` with Vue's reactivity system.  
+✔ **Svelte** → Works seamlessly as a store replacement.  
+
+## Next Steps
+
+➡ **[Extending Handlers](./extending-handlers.md)** – Customizing handlers for advanced use cases.  
+➡ **[Performance Optimizations](./performance.md)** – Improve performance with best practices.  

--- a/libraries/aelastics-store/src/common/observable-doc/docs/advanced/performance.md
+++ b/libraries/aelastics-store/src/common/observable-doc/docs/advanced/performance.md
@@ -1,0 +1,108 @@
+# Performance Optimizations
+
+## Introduction
+
+AelasticS-Observables uses JavaScript Proxies to efficiently track changes in objects, arrays, maps, and sets. However, improper usage can lead to **performance bottlenecks**. This guide covers best practices to **maximize efficiency** when using observables.
+
+## Avoiding Unnecessary Proxies
+
+By default, all properties of an observable object are **not automatically wrapped** in proxies. However, if you wrap deeply nested structures, it may cause **unnecessary overhead**.
+
+✅ **Best Practice:** Wrap only **top-level** objects and collections.
+
+```typescript
+const obj = createObservableObject({
+    nested: { count: 0 } // Not automatically an observable
+}, {});
+
+// Avoid wrapping deeply nested structures if not needed
+obj.nested = createObservableObject(obj.nested, {});
+```
+
+## Minimize Handler Overhead
+
+Every operation (set, delete, push, etc.) invokes the **corresponding handler**. **Overusing logging or validation** inside handlers can slow down execution.
+
+❌ **Inefficient handler:** Logs on every assignment.
+```typescript
+const handlers = {
+    set: (target, key, value) => {
+        console.log(`Setting ${String(key)} to ${value}`);
+        return true;
+    }
+};
+```
+✅ **Optimized handler:** Logs only when a value **actually changes**.
+```typescript
+const handlers = {
+    set: (target, key, value) => {
+        if (target[key] !== value) {
+            console.log(`Updated ${String(key)} to ${value}`);
+        }
+        return true;
+    }
+};
+```
+
+## Using Batch Updates
+
+Instead of making multiple individual updates, **batch updates** can significantly improve performance.
+
+❌ **Slow updates with multiple writes:**
+```typescript
+arr[0] = 1;
+arr[1] = 2;
+arr[2] = 3;
+```
+✅ **Faster batch updates using `.splice()` or `.push()`**:
+```typescript
+arr.splice(0, 3, 1, 2, 3); // Single operation
+```
+
+## Handling Large Collections Efficiently
+
+For large arrays, maps, or sets, frequent operations may become costly.
+
+### Optimizing Large Arrays
+
+✅ **Use methods like `.map()` instead of modifying elements one by one:**
+```typescript
+observableArr = observableArr.map(item => item * 2);
+```
+
+✅ **Prefer `.splice()` over multiple `.push()` calls:**  
+```typescript
+observableArr.splice(observableArr.length, 0, ...newItems);
+```
+
+### Optimizing Large Maps and Sets
+
+✅ **Use batch operations instead of multiple `.set()` or `.add()` calls:**  
+```typescript
+const entries = [["key1", "value1"], ["key2", "value2"]];
+entries.forEach(([key, value]) => observableMap.set(key, value));
+```
+
+## Measuring Performance
+
+Use **console.time()** to measure execution time.
+
+```typescript
+console.time("Mutation");
+for (let i = 0; i < 1000; i++) {
+    observableArr.push(i);
+}
+console.timeEnd("Mutation");
+```
+
+## Summary
+
+✔ **Wrap only necessary parts of an object**  
+✔ **Minimize heavy handlers like logging**  
+✔ **Use batch operations instead of multiple single mutations**  
+✔ **Optimize large collections efficiently**  
+✔ **Measure performance using `console.time()`**  
+
+## Next Steps
+
+➡ **[Integration](./integration.md)** – Learn how to use AelasticS-Observables with frameworks like React and Vue.  

--- a/libraries/aelastics-store/src/common/observable-doc/docs/api/api-observable-array.md
+++ b/libraries/aelastics-store/src/common/observable-doc/docs/api/api-observable-array.md
@@ -1,0 +1,74 @@
+# API: `createObservableArray`
+
+## Function Signature
+
+```typescript
+function createObservableArray<T, P extends {} = {}>(
+    arr: T[],
+    handlers: ArrayHandlers<T, P>,
+    defaultMutation?: boolean,
+    extra?: P
+): T[];
+```
+
+## Parameters
+
+| Name             | Type                     | Default | Description |
+|-----------------|-------------------------|---------|-------------|
+| `arr`           | `T[]`                     | —       | The array to make observable |
+| `handlers`      | `ArrayHandlers<T, P>`     | `{}`    | Custom handlers for operations |
+| `defaultMutation` | `boolean`              | `true`  | Whether to allow default mutations |
+| `extra`         | `P (optional)`           | `{}`    | Additional context for handlers |
+
+## Handlers
+
+| Handler          | Description |
+|-----------------|------------|
+| `set`          | Called when setting an item (`arr[index] = value`) |
+| `delete`       | Called when deleting an item (`delete arr[index]`) |
+| `push`        | Called when pushing new elements (`arr.push(value)`) |
+| `pop`         | Called when popping an element (`arr.pop()`) |
+| `shift`       | Called when shifting an element (`arr.shift()`) |
+| `unshift`     | Called when unshifting an element (`arr.unshift(value)`) |
+| `splice`      | Called when splicing elements (`arr.splice(start, deleteCount, items)`) |
+| `reverse`     | Called when reversing the array (`arr.reverse()`) |
+| `sort`        | Called when sorting the array (`arr.sort()`) |
+| `fill`        | Called when filling the array (`arr.fill(value, start, end)`) |
+| `defaultAction` | Called for any unhandled operations |
+
+## Example Usage
+
+### Basic Example
+
+```typescript
+import { createObservableArray } from 'aelastics-observables';
+
+const arr = createObservableArray([1, 2, 3], {
+    push: (target, items) => {
+        console.log(`Added ${items.length} items`);
+        return true;
+    }
+});
+
+arr.push(4, 5); // Logs: "Added 2 items"
+```
+
+### Using `extra` Parameter
+
+```typescript
+const handlers = {
+    push: (target, items, extra) => {
+        console.log(`[${extra.user}] Pushing items: ${items.join(", ")}`);
+        return true;
+    }
+};
+
+const arr = createObservableArray([1, 2, 3], handlers, true, { user: "admin" });
+arr.push(4); // Logs: "[admin] Pushing items: 4"
+```
+
+## Next Steps
+
+➡ **[Observable Objects](./api-observable-object.md)** – API reference for `createObservableObject`  
+➡ **[Observable Maps](./api-observable-map.md)** – API reference for `createObservableMap`  
+➡ **[Observable Sets](./api-observable-set.md)** – API reference for `createObservableSet`  

--- a/libraries/aelastics-store/src/common/observable-doc/docs/api/api-observable-map.md
+++ b/libraries/aelastics-store/src/common/observable-doc/docs/api/api-observable-map.md
@@ -1,0 +1,70 @@
+# API: `createObservableMap`
+
+## Function Signature
+
+```typescript
+function createObservableMap<K, V, P extends {} = {}>(
+    map: Map<K, V>,
+    handlers: MapHandlers<K, V, P>,
+    defaultMutation?: boolean,
+    extra?: P
+): Map<K, V>;
+```
+
+## Parameters
+
+| Name             | Type                     | Default | Description |
+|-----------------|-------------------------|---------|-------------|
+| `map`           | `Map<K, V>`               | —       | The map to make observable |
+| `handlers`      | `MapHandlers<K, V, P>`    | `{}`    | Custom handlers for operations |
+| `defaultMutation` | `boolean`              | `true`  | Whether to allow default mutations |
+| `extra`         | `P (optional)`           | `{}`    | Additional context for handlers |
+
+## Handlers
+
+| Handler          | Description |
+|-----------------|------------|
+| `set`          | Called when setting a key-value pair (`map.set(key, value)`) |
+| `delete`       | Called when deleting a key (`map.delete(key)`) |
+| `clear`        | Called when clearing all entries (`map.clear()`) |
+| `get`          | Called when retrieving a value (`map.get(key)`) |
+| `has`          | Called when checking key existence (`map.has(key)`) |
+| `forEach`      | Called when iterating over the map (`map.forEach(callback)`) |
+| `defaultAction` | Called for any unhandled operations |
+
+## Example Usage
+
+### Basic Example
+
+```typescript
+import { createObservableMap } from 'aelastics-observables';
+
+const map = createObservableMap(new Map(), {
+    set: (target, key, value) => {
+        console.log(`Key ${key} updated to ${value}`);
+        return true;
+    }
+});
+
+map.set('a', 10); // Logs: "Key a updated to 10"
+```
+
+### Using `extra` Parameter
+
+```typescript
+const handlers = {
+    set: (target, key, value, extra) => {
+        console.log(`[${extra.user}] Setting key ${key} to ${value}`);
+        return true;
+    }
+};
+
+const map = createObservableMap(new Map(), handlers, true, { user: "admin" });
+map.set("b", 20); // Logs: "[admin] Setting key b to 20"
+```
+
+## Next Steps
+
+➡ **[Observable Objects](./api-observable-object.md)** – API reference for `createObservableObject`  
+➡ **[Observable Arrays](./api-observable-array.md)** – API reference for `createObservableArray`  
+➡ **[Observable Sets](./api-observable-set.md)** – API reference for `createObservableSet`  

--- a/libraries/aelastics-store/src/common/observable-doc/docs/api/api-observable-object.md
+++ b/libraries/aelastics-store/src/common/observable-doc/docs/api/api-observable-object.md
@@ -1,0 +1,67 @@
+# API: `createObservableObject`
+
+## Function Signature
+
+```typescript
+function createObservableObject<T extends object, P extends {} = {}>(
+    obj: T,
+    handlers: ObjectHandlers<T, P>,
+    defaultMutation?: boolean,
+    extra?: P
+): T;
+```
+
+## Parameters
+
+| Name             | Type                     | Default | Description |
+|-----------------|-------------------------|---------|-------------|
+| `obj`           | `T`                       | —       | The object to make observable |
+| `handlers`      | `ObjectHandlers<T, P>`    | `{}`    | Custom handlers for operations |
+| `defaultMutation` | `boolean`              | `true`  | Whether to allow default mutations |
+| `extra`         | `P (optional)`           | `{}`    | Additional context for handlers |
+
+## Handlers
+
+| Handler          | Description |
+|-----------------|------------|
+| `set`          | Called when setting a property (`obj.key = value`) |
+| `delete`       | Called when deleting a property (`delete obj.key`) |
+| `method`       | Called when invoking a function on the object (`obj.method()`) |
+| `defaultAction` | Called for any unhandled operations |
+
+## Example Usage
+
+### Basic Example
+
+```typescript
+import { createObservableObject } from 'aelastics-observables';
+
+const obj = createObservableObject({ name: 'Alice' }, {
+    set: (target, key, value) => {
+        console.log(`Setting ${String(key)} to ${value}`);
+        return true;
+    }
+});
+
+obj.name = 'Bob'; // Logs: "Setting name to Bob"
+```
+
+### Using `extra` Parameter
+
+```typescript
+const handlers = {
+    set: (target, key, value, extra) => {
+        console.log(`[${extra.user}] Setting ${String(key)} to ${value}`);
+        return true;
+    }
+};
+
+const obj = createObservableObject({ name: "Alice" }, handlers, true, { user: "admin" });
+obj.name = "Bob"; // Logs: "[admin] Setting name to Bob"
+```
+
+## Next Steps
+
+➡ **[Observable Arrays](./api-observable-array.md)** – API reference for `createObservableArray`  
+➡ **[Observable Maps](./api-observable-map.md)** – API reference for `createObservableMap`  
+➡ **[Observable Sets](./api-observable-set.md)** – API reference for `createObservableSet`  

--- a/libraries/aelastics-store/src/common/observable-doc/docs/api/api-observable-set.md
+++ b/libraries/aelastics-store/src/common/observable-doc/docs/api/api-observable-set.md
@@ -1,0 +1,69 @@
+# API: `createObservableSet`
+
+## Function Signature
+
+```typescript
+function createObservableSet<T, P extends {} = {}>(
+    set: Set<T>,
+    handlers: SetHandlers<T, P>,
+    defaultMutation?: boolean,
+    extra?: P
+): Set<T>;
+```
+
+## Parameters
+
+| Name             | Type                     | Default | Description |
+|-----------------|-------------------------|---------|-------------|
+| `set`           | `Set<T>`                  | —       | The set to make observable |
+| `handlers`      | `SetHandlers<T, P>`       | `{}`    | Custom handlers for operations |
+| `defaultMutation` | `boolean`              | `true`  | Whether to allow default mutations |
+| `extra`         | `P (optional)`           | `{}`    | Additional context for handlers |
+
+## Handlers
+
+| Handler          | Description |
+|-----------------|------------|
+| `add`          | Called when adding a value (`set.add(value)`) |
+| `delete`       | Called when deleting a value (`set.delete(value)`) |
+| `clear`        | Called when clearing all values (`set.clear()`) |
+| `has`          | Called when checking value existence (`set.has(value)`) |
+| `forEach`      | Called when iterating over the set (`set.forEach(callback)`) |
+| `defaultAction` | Called for any unhandled operations |
+
+## Example Usage
+
+### Basic Example
+
+```typescript
+import { createObservableSet } from 'aelastics-observables';
+
+const set = createObservableSet(new Set(), {
+    add: (target, value) => {
+        console.log(`Value ${value} added`);
+        return true;
+    }
+});
+
+set.add(99); // Logs: "Value 99 added"
+```
+
+### Using `extra` Parameter
+
+```typescript
+const handlers = {
+    add: (target, value, extra) => {
+        console.log(`[${extra.user}] Adding value: ${value}`);
+        return true;
+    }
+};
+
+const set = createObservableSet(new Set(), handlers, true, { user: "admin" });
+set.add(42); // Logs: "[admin] Adding value: 42"
+```
+
+## Next Steps
+
+➡ **[Observable Objects](./api-observable-object.md)** – API reference for `createObservableObject`  
+➡ **[Observable Arrays](./api-observable-array.md)** – API reference for `createObservableArray`  
+➡ **[Observable Maps](./api-observable-map.md)** – API reference for `createObservableMap`  

--- a/libraries/aelastics-store/src/common/observable-doc/docs/api/api-overview.md
+++ b/libraries/aelastics-store/src/common/observable-doc/docs/api/api-overview.md
@@ -1,0 +1,82 @@
+# API Overview
+
+This section provides an overview of the **AelasticS-Observables** API, including function signatures, parameters, and return types.
+
+## Available Observable Structures
+
+AelasticS-Observables provides observability for common JavaScript/TypeScript data structures using proxies.
+
+| Data Structure | Function Implemented | Supported Handlers |
+|---------------|---------------------|----------------------|
+| **Objects**  | `createObservableObject` | `set`, `delete`, `method`, `defaultAction` |
+| **Arrays**   | `createObservableArray`  | `set`, `delete`, `push`, `pop`, `shift`, `unshift`, `splice`, `reverse`, `sort`, `fill`, `defaultAction` |
+| **Maps**     | `createObservableMap`    | `set`, `delete`, `clear`, `get`, `has`, `forEach`, `defaultAction` |
+| **Sets**     | `createObservableSet`    | `add`, `delete`, `clear`, `has`, `forEach`, `defaultAction` |
+
+Each function wraps a JavaScript data structure with a **Proxy** to intercept operations and apply custom handlers.
+
+## General API Structure
+
+Each observable creation function follows this structure:
+
+```typescript
+function createObservable<Type, Extra = {}>(
+    target: Type,
+    handlers: Handlers<Type, Extra>,
+    defaultMutation?: boolean,
+    extra?: Extra
+): Type;
+```
+
+### Parameters
+| Name             | Type                          | Default | Description |
+|-----------------|-----------------------------|---------|-------------|
+| `target`        | `Type`                        | —       | The object/array/map/set to make observable |
+| `handlers`      | `Handlers<Type, Extra>`       | `{}`    | Custom handlers for operations |
+| `defaultMutation` | `boolean`                   | `true`  | Whether to allow default mutations |
+| `extra`         | `Extra (optional)`            | `{}`    | Additional context for handlers |
+
+### Common Handlers
+- **`set(target, key, value, extra?)`** → Called when setting a property.
+- **`delete(target, key, extra?)`** → Called when deleting a property.
+- **`method(target, key, args[], extra?)`** → Called for function calls on objects.
+- **Collection-Specific Handlers**: `push`, `pop`, `add`, `clear`, `forEach`, etc.
+
+## Example Usage
+
+### Creating an Observable Object
+```typescript
+import { createObservableObject } from 'aelastics-observables';
+
+const obj = createObservableObject({ name: 'Alice' }, {
+    set: (target, key, value) => {
+        console.log(`Setting ${String(key)} to ${value}`);
+        return true;
+    }
+});
+
+obj.name = 'Bob'; // Logs: "Setting name to Bob"
+```
+
+### Creating an Observable Array
+```typescript
+import { createObservableArray } from 'aelastics-observables';
+
+const arr = createObservableArray([1, 2, 3], {
+    push: (target, items) => {
+        console.log(`Added ${items.length} items`);
+        return true;
+    }
+});
+
+arr.push(4, 5); // Logs: "Added 2 items"
+```
+
+## Next Steps
+
+Explore detailed API documentation for each observable type:
+
+➡ **[Observable Objects](./api-observable-object.md)** – API reference for `createObservableObject`  
+➡ **[Observable Arrays](./api-observable-array.md)** – API reference for `createObservableArray`  
+➡ **[Observable Maps](./api-observable-map.md)** – API reference for `createObservableMap`  
+➡ **[Observable Sets](./api-observable-set.md)** – API reference for `createObservableSet`  

--- a/libraries/aelastics-store/src/common/observable-doc/docs/core-concepts.md
+++ b/libraries/aelastics-store/src/common/observable-doc/docs/core-concepts.md
@@ -1,0 +1,138 @@
+# Core Concepts
+
+## Understanding Observables
+
+In **AelasticS-Observables**, observables are **JavaScript objects, arrays, maps, and sets** wrapped in a **Proxy**. This allows for real-time interception of changes and tracking of modifications.
+
+Observables enable:
+- **Automatic tracking** of state changes.
+- **Customizable handlers** for modifying behavior.
+- **Efficient, proxy-based observability** with low overhead.
+
+## How Proxies Work
+
+A **Proxy** in JavaScript wraps an object and intercepts operations like:
+- Property access (`obj.key`)
+- Assignments (`obj.key = value`)
+- Deletions (`delete obj.key`)
+- Function calls (`obj.method()`)
+
+Example of a basic Proxy:
+```typescript
+const obj = new Proxy({}, {
+    set(target, key, value) {
+        console.log(`Setting ${String(key)} to ${value}`);
+        target[key] = value;
+        return true;
+    }
+});
+
+obj.name = "Alice"; // Logs: "Setting name to Alice"
+```
+
+## Handlers in AelasticS-Observables
+
+Handlers define **how** modifications to observables are managed. Each data structure supports different handlers.
+
+### **Handlers for Objects**
+| Handler | Description |
+|---------|------------|
+| `set` | Intercepts property assignments (`obj.key = value`) |
+| `delete` | Intercepts deletions (`delete obj.key`) |
+| `method` | Intercepts method calls (`obj.method()`) |
+| `defaultAction` | Called for any unhandled operations |
+
+Example:
+```typescript
+const obj = createObservableObject({ count: 0 }, {
+    set: (target, key, value) => {
+        console.log(`Setting ${String(key)} to ${value}`);
+        return true;
+    }
+});
+obj.count = 10; // Logs: "Setting count to 10"
+```
+
+### **Handlers for Arrays**
+| Handler | Description |
+|---------|------------|
+| `set` | Intercepts item assignments (`arr[0] = value`) |
+| `delete` | Intercepts deletions (`delete arr[0]`) |
+| `push`, `pop`, `shift`, `unshift`, `splice` | Intercepts respective array methods |
+| `reverse`, `sort`, `fill` | Intercepts transformation methods |
+| `defaultAction` | Called for any unhandled operations |
+
+Example:
+```typescript
+const arr = createObservableArray([1, 2, 3], {
+    push: (target, items) => {
+        console.log(`Added ${items.length} items`);
+        return true;
+    }
+});
+arr.push(4); // Logs: "Added 1 item"
+```
+
+### **Handlers for Maps**
+| Handler | Description |
+|---------|------------|
+| `set` | Intercepts key-value assignments (`map.set(key, value)`) |
+| `delete` | Intercepts deletions (`map.delete(key)`) |
+| `clear` | Intercepts `map.clear()` |
+| `get`, `has`, `forEach` | Intercepts respective operations |
+| `defaultAction` | Called for any unhandled operations |
+
+Example:
+```typescript
+const map = createObservableMap(new Map(), {
+    set: (target, key, value) => {
+        console.log(`Setting ${key} to ${value}`);
+        return true;
+    }
+});
+map.set("a", 42); // Logs: "Setting a to 42"
+```
+
+### **Handlers for Sets**
+| Handler | Description |
+|---------|------------|
+| `add` | Intercepts additions (`set.add(value)`) |
+| `delete` | Intercepts deletions (`set.delete(value)`) |
+| `clear` | Intercepts `set.clear()` |
+| `has`, `forEach` | Intercepts respective operations |
+| `defaultAction` | Called for any unhandled operations |
+
+Example:
+```typescript
+const set = createObservableSet(new Set(), {
+    add: (target, value) => {
+        console.log(`Added value: ${value}`);
+        return true;
+    }
+});
+set.add(99); // Logs: "Added value: 99"
+```
+
+## The `extra` Parameter
+
+All handlers receive an **optional `extra` parameter**, which allows developers to pass **context information** into handlers.
+
+Example:
+```typescript
+const handlers = {
+    set: (target, key, value, extra) => {
+        console.log(`[${extra.user}] Setting ${String(key)} to ${value}`);
+        return true;
+    }
+};
+
+const obj = createObservableObject({ name: "Alice" }, handlers, true, { user: "admin" });
+obj.name = "Bob"; // Logs: "[admin] Setting name to Bob"
+```
+
+## Next Steps
+
+To dive deeper into AelasticS-Observables, check out:
+
+➡ **[API Reference](./api/api-overview.md)** – Learn about function signatures and parameters.  
+➡ **[Advanced Topics](./advanced/extending-handlers.md)** – Customizing and extending observability.  

--- a/libraries/aelastics-store/src/common/observable-doc/docs/getting-started.md
+++ b/libraries/aelastics-store/src/common/observable-doc/docs/getting-started.md
@@ -1,0 +1,89 @@
+# Getting Started
+
+Welcome to **AelasticS-Observables**! This guide will help you quickly set up and start using the library.
+
+## Installation
+
+To install AelasticS-Observables, use **npm** or **yarn**:
+
+```sh
+# Using npm
+npm install aelastics-observables
+
+# Using yarn
+yarn add aelastics-observables
+```
+
+## Basic Usage
+
+### 1️⃣ Creating an Observable Object
+Use `createObservableObject` to make an object reactive.
+
+```typescript
+import { createObservableObject } from 'aelastics-observables';
+
+const obj = createObservableObject({ count: 0 }, {
+    set: (target, key, value) => {
+        console.log(`Property ${String(key)} changed to ${value}`);
+        return true;
+    }
+});
+
+obj.count = 42; // Logs: "Property count changed to 42"
+```
+
+### 2️⃣ Creating an Observable Array
+Use `createObservableArray` to observe changes to an array.
+
+```typescript
+import { createObservableArray } from 'aelastics-observables';
+
+const arr = createObservableArray([1, 2, 3], {
+    push: (target, items) => {
+        console.log(`Added ${items.length} items`);
+        return true;
+    }
+});
+
+arr.push(4, 5); // Logs: "Added 2 items"
+```
+
+### 3️⃣ Creating an Observable Map
+Use `createObservableMap` to track modifications in a `Map`.
+
+```typescript
+import { createObservableMap } from 'aelastics-observables';
+
+const map = createObservableMap(new Map(), {
+    set: (target, key, value) => {
+        console.log(`Key ${key} updated to ${value}`);
+        return true;
+    }
+});
+
+map.set('a', 10); // Logs: "Key a updated to 10"
+```
+
+### 4️⃣ Creating an Observable Set
+Use `createObservableSet` to monitor changes in a `Set`.
+
+```typescript
+import { createObservableSet } from 'aelastics-observables';
+
+const set = createObservableSet(new Set(), {
+    add: (target, value) => {
+        console.log(`Value ${value} added`);
+        return true;
+    }
+});
+
+set.add(99); // Logs: "Value 99 added"
+```
+
+## Next Steps
+
+To learn more, explore the following guides:
+
+➡ **[Core Concepts](./core-concepts.md)** – Learn how observables and handlers work  
+➡ **[API Reference](./api/api-overview.md)** – Detailed function documentation  
+➡ **[Advanced Topics](./advanced/extending-handlers.md)** – Customize observables with custom handlers  

--- a/libraries/aelastics-store/src/common/observable-doc/docs/guides/observable-array.md
+++ b/libraries/aelastics-store/src/common/observable-doc/docs/guides/observable-array.md
@@ -1,0 +1,3 @@
+# Observable Arrays
+
+## How to use observable arrays.

--- a/libraries/aelastics-store/src/common/observable-doc/docs/guides/observable-map.md
+++ b/libraries/aelastics-store/src/common/observable-doc/docs/guides/observable-map.md
@@ -1,0 +1,3 @@
+# Observable Maps
+
+## How to use observable maps.

--- a/libraries/aelastics-store/src/common/observable-doc/docs/guides/observable-object.md
+++ b/libraries/aelastics-store/src/common/observable-doc/docs/guides/observable-object.md
@@ -1,0 +1,3 @@
+# Observable Objects
+
+## How to use observable objects.

--- a/libraries/aelastics-store/src/common/observable-doc/docs/guides/observable-set.md
+++ b/libraries/aelastics-store/src/common/observable-doc/docs/guides/observable-set.md
@@ -1,0 +1,3 @@
+# Observable Sets
+
+## How to use observable sets.

--- a/libraries/aelastics-store/src/common/observable-doc/docs/introduction.md
+++ b/libraries/aelastics-store/src/common/observable-doc/docs/introduction.md
@@ -1,0 +1,63 @@
+# Introduction
+
+## What is AelasticS-Observables?
+
+**AelasticS-Observables** is a JavaScript/TypeScript library that provides **observable data structures** using the Proxy API. It allows developers to track changes to objects, arrays, maps, and sets efficiently while maintaining a **clean and declarative API**.
+
+## Why Use AelasticS-Observables?
+
+Managing state changes in JavaScript applications often requires deep tracking mechanisms. **AelasticS-Observables** simplifies this by:
+- Automatically **tracking modifications** to structured data types.
+- Providing **customizable handlers** for intercepting actions (`set`, `delete`, `push`, etc.).
+- Offering an **optional `extra` context parameter** for passing metadata.
+- Supporting **fine-grained control** over mutation behavior.
+- Being **lightweight** and compatible with modern JavaScript/TypeScript.
+
+## Key Features
+
+✔ **Observable Objects, Arrays, Maps, and Sets**  
+✔ **Customizable Handlers for State Modifications**  
+✔ **Efficient Proxy-based Observability**  
+✔ **Optional `extra` Metadata Parameter**  
+✔ **Works Seamlessly with TypeScript**  
+
+## How AelasticS-Observables Works
+
+The library wraps objects and collections with **Proxies**, allowing interception of:
+- **Property modifications** (e.g., `obj.name = "Alice"`)
+- **Method calls** (e.g., `array.push(42)`)
+- **Deletions** (e.g., `delete obj.name`)
+- **Collection updates** (e.g., `map.set("key", "value")`)
+
+## Supported Observable Structures
+
+| Data Structure | Function Implemented | Supported Handlers |
+|---------------|---------------------|----------------------|
+| **Objects**  | `createObservableObject` | `set`, `delete`, `method`, `defaultAction` |
+| **Arrays**   | `createObservableArray`  | `set`, `delete`, `push`, `pop`, `shift`, `unshift`, `splice`, `reverse`, `sort`, `fill`, `defaultAction` |
+| **Maps**     | `createObservableMap`    | `set`, `delete`, `clear`, `get`, `has`, `forEach`, `defaultAction` |
+| **Sets**     | `createObservableSet`    | `add`, `delete`, `clear`, `has`, `forEach`, `defaultAction` |
+
+## Example Usage
+
+```typescript
+import { createObservableObject } from 'aelastics-observables';
+
+const obj = createObservableObject({ name: 'Alice' }, {
+    set: (target, key, value) => {
+        console.log(`Setting ${String(key)} to ${value}`);
+        return true;
+    }
+});
+
+obj.name = 'Bob'; // Logs: "Setting name to Bob"
+```
+
+## Next Steps
+
+To get started with **AelasticS-Observables**, continue with the following guides:
+
+➡ **[Getting Started](./getting-started.md)** – Install and set up the library  
+➡ **[Core Concepts](./core-concepts.md)** – Learn about proxies and handlers  
+➡ **[API Reference](./api/api-overview.md)** – Explore detailed function documentation  
+➡ **[Advanced Topics](./advanced/extending-handlers.md)** – Extend observability for custom use cases  

--- a/libraries/aelastics-store/src/common/observable-doc/sidebars.js
+++ b/libraries/aelastics-store/src/common/observable-doc/sidebars.js
@@ -1,0 +1,22 @@
+
+module.exports = {
+  docs: [
+    'introduction',
+    'getting-started',
+    {
+      type: 'category',
+      label: 'Guides',
+      items: ['guides/observable-object', 'guides/observable-array', 'guides/observable-map', 'guides/observable-set'],
+    },
+    {
+      type: 'category',
+      label: 'API Reference',
+      items: ['api/api-overview', 'api/api-observable-object', 'api/api-observable-array', 'api/api-observable-map', 'api/api-observable-set'],
+    },
+    {
+      type: 'category',
+      label: 'Advanced',
+      items: ['advanced/extending-handlers', 'advanced/performance', 'advanced/integration'],
+    },
+  ],
+};

--- a/libraries/aelastics-store/src/common/observableArray.test.ts
+++ b/libraries/aelastics-store/src/common/observableArray.test.ts
@@ -1,141 +1,170 @@
-/*
- * Project: aelastics-store
- * Created Date: Tuesday September 12th 2023
- * Author: Sinisa Neskovic (https://github.com/Sinisa-Neskovic)
- * -----
- * Last Modified: Saturday, 16th September 2023
- * Modified By: Sinisa Neskovic (https://github.com/Sinisa-Neskovic)
- * -----
- * Copyright (c) 2023 Aelastics (https://github.com/AelasticS)
- */
-
-import { createObservableArray } from './observableArray';
+import { createObservableArray, ArrayHandlers } from './observableArray';
 
 describe('createObservableArray', () => {
-    // Test the `set` handler.
-    it('set: should update the array if handler returns true and be called with correct arguments', () => {
-        const mockSetHandler = jest.fn((target, index, value) => true);
-        const arr = createObservableArray<number>([1, 2, 3], { set: mockSetHandler });
+    it('should call the set handler with extra parameter', () => {
+        const target = [1, 2, 3];
+        const extra = { context: 'test' };
+        const handlers: ArrayHandlers<number, typeof extra> = {
+            set: jest.fn().mockReturnValue(true),
+        };
 
-        arr[1] = 99;
+        const proxy = createObservableArray(target, handlers, true, extra);
+        proxy[1] = 99;
 
-        expect(arr[1]).toBe(99);
-
-        // expect(mockSetHandler.mock.calls[0][0]).toMatchObject([1, 2, 3]); 
-        // array is tested after mutation
-        expect(mockSetHandler).toHaveBeenCalledWith(expect.arrayContaining([1, 99, 3]), 1, 99);
-
+        expect(handlers.set).toHaveBeenCalledWith(target, 1, 99, extra);
+        expect(target[1]).toBe(99);
     });
 
-    // Test the `delete` handler.
-    it('delete: should delete the element if handler returns true and be called with correct arguments', () => {
-        const mockDeleteHandler = jest.fn((target, index) => true);
-        const arr = createObservableArray<number>([1, 2, 3], { delete: mockDeleteHandler });
+    it('should call the delete handler with extra parameter', () => {
+        const target = [1, 2, 3];
+        const extra = { context: 'test' };
+        const handlers: ArrayHandlers<number, typeof extra> = {
+            delete: jest.fn().mockReturnValue(true),
+        };
 
-        delete arr[1];
+        const proxy = createObservableArray(target, handlers, true, extra);
+        delete proxy[1];
 
-        expect(arr[1]).toBeUndefined();
-        expect(mockDeleteHandler).toHaveBeenCalledWith(expect.arrayContaining([1, , 3]), 1);
+        expect(handlers.delete).toHaveBeenCalledWith(target, 1, extra);
+        expect(target[1]).toBeUndefined();
     });
 
-    // Test the `push` handler.
-    it('push: should add element if handler returns true and be called with correct arguments', () => {
-        const mockPushHandler = jest.fn((target, items) => true);
-        const arr = createObservableArray<number>([1, 2, 3], { push: mockPushHandler });
+    it('should call the push handler with extra parameter', () => {
+        const target = [1, 2, 3];
+        const extra = { context: 'test' };
+        const handlers: ArrayHandlers<number, typeof extra> = {
+            push: jest.fn().mockReturnValue(true),
+        };
 
-        arr.push(4);
+        const proxy = createObservableArray(target, handlers, true, extra);
+        proxy.push(4, 5);
 
-        expect(arr[3]).toBe(4);
-        expect(mockPushHandler).toHaveBeenCalledWith(expect.arrayContaining([1, 2, 3]), expect.arrayContaining([4]));
+        expect(handlers.push).toHaveBeenCalledWith(target, [4, 5], extra);
+        expect(target).toEqual([1, 2, 3, 4, 5]);
     });
 
-    // Test the `pop` handler.
-    it('pop: should remove the last element if handler returns true and be called with correct arguments', () => {
-        const mockPopHandler = jest.fn((target) => true);
-        const arr = createObservableArray<number>([1, 2, 3], { pop: mockPopHandler });
+    it('should call the pop handler with extra parameter', () => {
+        const target = [1, 2, 3];
+        const extra = { context: 'test' };
+        const handlers: ArrayHandlers<number, typeof extra> = {
+            pop: jest.fn().mockReturnValue(true),
+        };
 
-        const popped = arr.pop();
+        const proxy = createObservableArray(target, handlers, true, extra);
+        proxy.pop();
 
-        expect(popped).toBe(3);
-        expect(arr.length).toBe(2);
-        expect(mockPopHandler).toHaveBeenCalledWith(expect.arrayContaining([1, 2]));
+        expect(handlers.pop).toHaveBeenCalledWith(target, extra);
+        expect(target).toEqual([1, 2]);
     });
 
-    // Test the `shift` handler.
-    it('shift: should remove the first element if handler returns true and be called with correct arguments', () => {
-        const mockShiftHandler = jest.fn((target) => true);
-        const arr = createObservableArray<number>([1, 2, 3], { shift: mockShiftHandler });
+    it('should call the shift handler with extra parameter', () => {
+        const target = [1, 2, 3];
+        const extra = { context: 'test' };
+        const handlers: ArrayHandlers<number, typeof extra> = {
+            shift: jest.fn().mockReturnValue(true),
+        };
 
-        const shifted = arr.shift();
+        const proxy = createObservableArray(target, handlers, true, extra);
+        proxy.shift();
 
-        expect(shifted).toBe(1);
-        expect(arr).toEqual([2, 3]);
-        expect(mockShiftHandler).toHaveBeenCalledWith(expect.arrayContaining([2, 3]));
+        expect(handlers.shift).toHaveBeenCalledWith(target, extra);
+        expect(target).toEqual([2, 3]);
     });
 
-    // Test the `unshift` handler.
-    it('unshift: should add elements to the start of the array if handler returns true and be called with correct arguments', () => {
-        const mockUnshiftHandler = jest.fn((target, items) => true);
-        const arr = createObservableArray<number>([1, 2, 3], { unshift: mockUnshiftHandler });
+    it('should call the unshift handler with extra parameter', () => {
+        const target = [1, 2, 3];
+        const extra = { context: 'test' };
+        const handlers: ArrayHandlers<number, typeof extra> = {
+            unshift: jest.fn().mockReturnValue(true),
+        };
 
-        arr.unshift(0);
+        const proxy = createObservableArray(target, handlers, true, extra);
+        proxy.unshift(0);
 
-        expect(arr).toEqual([0, 1, 2, 3]);
-        expect(mockUnshiftHandler).toHaveBeenCalledWith(expect.arrayContaining([0, 1, 2, 3]), expect.arrayContaining([0]));
+        expect(handlers.unshift).toHaveBeenCalledWith(target, [0], extra);
+        expect(target).toEqual([0, 1, 2, 3]);
     });
 
-    // Test the `splice` handler.
-    it('splice: should modify the array correctly if handler returns true and be called with correct arguments', () => {
-        const mockSpliceHandler = jest.fn((target, start, deleteCount, items) => true);
-        const arr = createObservableArray<number>([1, 2, 3], { splice: mockSpliceHandler });
+    it('should call the splice handler with extra parameter', () => {
+        const target = [1, 2, 3, 4];
+        const extra = { context: 'test' };
+        const handlers: ArrayHandlers<number, typeof extra> = {
+            splice: jest.fn().mockReturnValue(true),
+        };
 
-        arr.splice(1, 1, 99);
+        const proxy = createObservableArray(target, handlers, true, extra);
+        proxy.splice(1, 2, 99, 100);
 
-        expect(arr).toEqual([1, 99, 3]);
-        expect(mockSpliceHandler).toHaveBeenCalledWith(expect.arrayContaining([1, 99, 3]), 1, 1, expect.arrayContaining([99]));
+        expect(handlers.splice).toHaveBeenCalledWith(target, 1, 2, [99, 100], extra);
+        expect(target).toEqual([1, 99, 100, 4]);
     });
 
-    // Test the `reverse` handler.
-    it('reverse: should reverse the array if handler returns true and be called with correct arguments', () => {
-        const mockReverseHandler = jest.fn((target) => true);
-        const arr = createObservableArray<number>([1, 2, 3], { reverse: mockReverseHandler });
+    it('should call the reverse handler with extra parameter', () => {
+        const target = [1, 2, 3];
+        const extra = { context: 'test' };
+        const handlers: ArrayHandlers<number, typeof extra> = {
+            reverse: jest.fn().mockReturnValue(true),
+        };
 
-        arr.reverse();
+        const proxy = createObservableArray(target, handlers, true, extra);
+        proxy.reverse();
 
-        expect(arr).toEqual([3, 2, 1]);
-        expect(mockReverseHandler).toHaveBeenCalledWith(expect.arrayContaining([3, 2, 1]));
+        expect(handlers.reverse).toHaveBeenCalledWith(target, extra);
+        expect(target).toEqual([3, 2, 1]);
     });
 
-    // Test the `sort` handler.
-    it('sort: should sort the array if handler returns true and be called with correct arguments', () => {
-        const mockSortHandler = jest.fn((target) => true);
-        const arr = createObservableArray<number>([3, 1, 2], { sort: mockSortHandler });
+    it('should call the sort handler with extra parameter', () => {
+        const target = [3, 1, 2];
+        const extra = { context: 'test' };
+        const handlers: ArrayHandlers<number, typeof extra> = {
+            sort: jest.fn().mockReturnValue(true),
+        };
 
-        arr.sort();
+        const proxy = createObservableArray(target, handlers, true, extra);
+        proxy.sort();
 
-        expect(arr).toEqual([1, 2, 3]);
-        expect(mockSortHandler).toHaveBeenCalledWith(expect.arrayContaining([1, 2, 3]));
+        expect(handlers.sort).toHaveBeenCalledWith(target, extra);
+        expect(target).toEqual([1, 2, 3]);
     });
 
-    // Test the `fill` handler.
-    it('fill: should fill the array with the specified value if handler returns true and be called with correct arguments', () => {
-        const mockFillHandler = jest.fn((target, value, start, end) => true);
-        const arr = createObservableArray<number>([1, 2, 3], { fill: mockFillHandler });
+    it('should call the fill handler with extra parameter', () => {
+        const target = [1, 2, 3];
+        const extra = { context: 'test' };
+        const handlers: ArrayHandlers<number, typeof extra> = {
+            fill: jest.fn().mockReturnValue(true),
+        };
 
-        arr.fill(0, 1, 3);
+        const proxy = createObservableArray(target, handlers, true, extra);
+        proxy.fill(0, 1, 3);
 
-        expect(arr).toEqual([1, 0, 0]);
-        expect(mockFillHandler).toHaveBeenCalledWith(expect.arrayContaining([1, 0, 0]), 0, 1, 3);
+        expect(handlers.fill).toHaveBeenCalledWith(target, 0, 1, 3, extra);
+        expect(target).toEqual([1, 0, 0]);
     });
 
-    // Test the `defaultAction` handler.
-    it('defaultAction: should be called when accessing an unknown property', () => {
-        const mockDefaultActionHandler = jest.fn((target, key) => true);
-        const arr = createObservableArray<number>([1, 2, 3], { defaultAction: mockDefaultActionHandler });
+    it('should call the defaultAction handler with extra parameter', () => {
+        const target = [1, 2, 3];
+        const extra = { context: 'test' };
+        const handlers: ArrayHandlers<number, typeof extra> = {
+            defaultAction: jest.fn().mockReturnValue(true),
+        };
 
-        const value = arr.length;
+        const proxy = createObservableArray(target, handlers, true, extra);
+        const length = proxy.length;
 
-        expect(mockDefaultActionHandler).toHaveBeenCalledWith(expect.arrayContaining([1, 2, 3]), 'length');
-        expect(value).toBe(3)
+        expect(handlers.defaultAction).toHaveBeenCalledWith(target, 'length', [], extra);
+        expect(length).toBe(3);
+    });
+
+    it('should handle absence of extra parameter gracefully', () => {
+        const target = [1, 2, 3];
+        const handlers: ArrayHandlers<number> = {
+            set: jest.fn().mockReturnValue(true),
+        };
+
+        const proxy = createObservableArray(target, handlers);
+        proxy[1] = 99;
+
+        expect(handlers.set).toHaveBeenCalledWith(target, 1, 99, undefined);
+        expect(target[1]).toBe(99);
     });
 });

--- a/libraries/aelastics-store/src/common/observableMap.ts
+++ b/libraries/aelastics-store/src/common/observableMap.ts
@@ -1,77 +1,79 @@
-/*
- * Project: aelastics-store
- * Created Date: Tuesday September 12th 2023
- * Author: Sinisa Neskovic (https://github.com/Sinisa-Neskovic)
- * -----
- * Last Modified: Saturday, 16th September 2023
- * Modified By: Sinisa Neskovic (https://github.com/Sinisa-Neskovic)
- * -----
- * Copyright (c) 2023 Aelastics (https://github.com/AelasticS)
- */
-
-export interface MapHandlers<K, V> {
-    set?: (target: Map<K, V>, key: K, value: V) => boolean;
-    delete?: (target: Map<K, V>, key: K) => boolean;
-    clear?: (target: Map<K, V>) => boolean;
-    defaultAction?: (target: Map<K, V>, key: PropertyKey) => boolean;
+export interface MapHandlers<K, V, P extends {} = {}> {
+    set?: (target: Map<K, V>, key: K, value: V, extra?: P) => boolean;
+    delete?: (target: Map<K, V>, key: K, extra?: P) => boolean;
+    clear?: (target: Map<K, V>, extra?: P) => boolean;
+    get?: (target: Map<K, V>, key: K, extra?: P) => boolean;
+    has?: (target: Map<K, V>, key: K, extra?: P) => boolean;
+    forEach?: (target: Map<K, V>, callback: (value: V, key: K, map: Map<K, V>) => void, extra?: P) => boolean;
+    defaultAction?: (target: Map<K, V>, key: PropertyKey, args?: any[], extra?: P) => boolean;
 }
 
-export function createObservableMap<K, V>(
+export function createObservableMap<K, V, P extends {} = {}>(
     map: Map<K, V>,
-    handlers: MapHandlers<K, V>,
-    defaultMutation: boolean = true
+    handlers: MapHandlers<K, V, P>,
+    defaultMutation: boolean = true,
+    extra?: P
 ): Map<K, V> {
     return new Proxy(map, {
-        get(target: Map<K, V>, key: PropertyKey) {
-            switch (key) {
-                case 'set':
-                    return function (k: K, v: V): void {
-                        if (handlers.set) {
-                            const allowMutation = handlers.set(target, k, v);
-                            if (allowMutation) {
-                                target.set(k, v);
-                            }
-                        } else if (defaultMutation) {
-                            target.set(k, v);
-                        }
-                    };
-                case 'delete':
-                    return function (k: K): boolean {
-                        if (handlers.delete) {
-                            const allowMutation = handlers.delete(target, k);
-                            if (allowMutation) {
-                                return target.delete(k);
-                            }
-                            return false;  // Or whatever default behavior you want when mutation is not allowed
-                        } else if (defaultMutation) {
-                            return target.delete(k);
-                        }
-                        return false;  // Default behavior if no delete handler and defaultMutation is false
-                    };
-                case 'clear':
-                    return function (): void {
-                        if (handlers.clear) {
-                            const allowMutation = handlers.clear(target);
-                            if (allowMutation) {
-                                target.clear();
-                            }
-                        } else if (defaultMutation) {
-                            target.clear();
-                        }
-                    };
-                case 'get':
-                    return function (k: K): V | undefined {
-                        return target.get(k);
-                    };
-                default:
-                    if (handlers.defaultAction) {
-                        const allowDefault = handlers.defaultAction(target, key);
-                        if (!allowDefault) {
-                            return undefined;
-                        }
-                    }
-                    return target[key as keyof typeof target];
+        get(target: Map<K, V>, key: string | number | symbol, receiver: any): any {
+            // Handle standard map methods
+            if (typeof key === 'string') {
+                switch (key) {
+                    case 'set':
+                        return (k: K, v: V) => {
+                            const allowSet = handlers.set?.(target, k, v, extra) ?? defaultMutation;
+                            return allowSet ? Reflect.apply(target.set, target, [k, v]) : target;
+                        };
+                    case 'delete':
+                        return (k: K) => {
+                            const allowDelete = handlers.delete?.(target, k, extra) ?? defaultMutation;
+                            return allowDelete ? Reflect.apply(target.delete, target, [k]) : false;
+                        };
+                    case 'clear':
+                        return () => {
+                            const allowClear = handlers.clear?.(target, extra) ?? defaultMutation;
+                            return allowClear ? Reflect.apply(target.clear, target, []) : undefined;
+                        };
+                    case 'get':
+                        return (k: K) => {
+                            const allowGet = handlers.get?.(target, k, extra) ?? defaultMutation;
+                            return allowGet ? Reflect.apply(target.get, target, [k]) : undefined;
+                        };
+                    case 'has':
+                        return (k: K) => {
+                            const allowHas = handlers.has?.(target, k, extra) ?? defaultMutation;
+                            return allowHas ? Reflect.apply(target.has, target, [k]) : false;
+                        };
+                    case 'forEach':
+                        return (callback: (value: V, key: K, map: Map<K, V>) => void) => {
+                            const allowForEach = handlers.forEach?.(target, callback, extra) ?? defaultMutation;
+                            return allowForEach ? Reflect.apply(target.forEach, target, [callback]) : undefined;
+                        };
+                }
             }
+
+            // Handle property getters like `size`
+            const propDescriptor = Object.getOwnPropertyDescriptor(Map.prototype, key);
+            if (propDescriptor?.get) {
+                if (handlers.defaultAction) {
+                    const allowDefault = handlers.defaultAction(target, key, [], extra);
+                    if (!allowDefault) {
+                        return undefined;
+                    }
+                }
+                return Reflect.get(target, key);
+            }
+
+            // Default behavior for other properties
+            const origProp = Reflect.get(target, key, receiver);
+            if (handlers.defaultAction) {
+                const allowDefault = handlers.defaultAction(target, key, [], extra);
+                if (!allowDefault) {
+                    return undefined;
+                }
+            }
+            return origProp;
         }
     });
 }
+

--- a/libraries/aelastics-store/src/common/observableObject.test.ts
+++ b/libraries/aelastics-store/src/common/observableObject.test.ts
@@ -1,14 +1,3 @@
-/*
- * Project: aelastics-store
- * Created Date: Tuesday September 12th 2023
- * Author: Sinisa Neskovic (https://github.com/Sinisa-Neskovic)
- * -----
- * Last Modified: Saturday, 16th September 2023
- * Modified By: Sinisa Neskovic (https://github.com/Sinisa-Neskovic)
- * -----
- * Copyright (c) 2023 Aelastics (https://github.com/AelasticS)
- */
-
 import { createObservableObject } from './observableObject';
 
 describe('createObservableObject', () => {

--- a/libraries/aelastics-store/src/common/observableObject.ts
+++ b/libraries/aelastics-store/src/common/observableObject.ts
@@ -1,14 +1,3 @@
-/*
- * Project: aelastics-store
- * Created Date: Tuesday September 12th 2023
- * Author: Sinisa Neskovic (https://github.com/Sinisa-Neskovic)
- * -----
- * Last Modified: Saturday, 31 Janjuary 2025
- * Modified By: Sinisa Neskovic (https://github.com/Sinisa-Neskovic)
- * -----
- * Copyright (c) 2025 Aelastics (https://github.com/AelasticS)
- */
-
 export interface ObjectHandlers<T extends object, P extends {} = {}> {
     set?: (target: T, key: string | number | symbol, value: any, extra?: P) => boolean;
     delete?: (target: T, key: string | number | symbol, extra?: P) => boolean;

--- a/libraries/aelastics-store/src/common/observableSet.test.ts
+++ b/libraries/aelastics-store/src/common/observableSet.test.ts
@@ -1,0 +1,103 @@
+import { createObservableSet, SetHandlers } from './observableSet';
+
+describe('createObservableSet', () => {
+    it('should call the add handler with extra parameter', () => {
+        const target = new Set<number>();
+        const extra = { context: 'test' };
+        const handlers: SetHandlers<number, typeof extra> = {
+            add: jest.fn().mockReturnValue(true),
+        };
+
+        const proxy = createObservableSet(target, handlers, true, extra);
+        proxy.add(100);
+
+        expect(handlers.add).toHaveBeenCalledWith(target, 100, extra);
+        expect(target.has(100)).toBe(true);
+    });
+
+    it('should call the delete handler with extra parameter', () => {
+        const target = new Set<number>([1, 2, 3]);
+        const extra = { context: 'test' };
+        const handlers: SetHandlers<number, typeof extra> = {
+            delete: jest.fn().mockReturnValue(true),
+        };
+
+        const proxy = createObservableSet(target, handlers, true, extra);
+        proxy.delete(2);
+
+        expect(handlers.delete).toHaveBeenCalledWith(target, 2, extra);
+        expect(target.has(2)).toBe(false);
+    });
+
+    it('should call the clear handler with extra parameter', () => {
+        const target = new Set<number>([1, 2, 3]);
+        const extra = { context: 'test' };
+        const handlers: SetHandlers<number, typeof extra> = {
+            clear: jest.fn().mockReturnValue(true),
+        };
+
+        const proxy = createObservableSet(target, handlers, true, extra);
+        proxy.clear();
+
+        expect(handlers.clear).toHaveBeenCalledWith(target, extra);
+        expect(target.size).toBe(0);
+    });
+
+    it('should call the has handler with extra parameter', () => {
+        const target = new Set<number>([1, 2, 3]);
+        const extra = { context: 'test' };
+        const handlers: SetHandlers<number, typeof extra> = {
+            has: jest.fn().mockReturnValue(true),
+        };
+
+        const proxy = createObservableSet(target, handlers, true, extra);
+        const result = proxy.has(1);
+
+        expect(handlers.has).toHaveBeenCalledWith(target, 1, extra);
+        expect(result).toBe(true);
+    });
+
+    it('should call the forEach handler with extra parameter', () => {
+        const target = new Set<number>([1, 2, 3]);
+        const extra = { context: 'test' };
+        const handlers: SetHandlers<number, typeof extra> = {
+            forEach: jest.fn().mockReturnValue(true),
+        };
+
+        const proxy = createObservableSet(target, handlers, true, extra);
+        proxy.forEach((value) => {});
+
+        expect(handlers.forEach).toHaveBeenCalledWith(
+            target,
+            expect.any(Function),
+            extra
+        );
+    });
+
+    it('should call the defaultAction handler with extra parameter', () => {
+        const target = new Set<number>([1]);
+        const extra = { context: 'test' };
+        const handlers: SetHandlers<number, typeof extra> = {
+            defaultAction: jest.fn().mockReturnValue(true),
+        };
+
+        const proxy = createObservableSet(target, handlers, true, extra);
+        const size = proxy.size;
+
+        expect(handlers.defaultAction).toHaveBeenCalledWith(target, 'size', [], extra);
+        expect(size).toBe(1);
+    });
+
+    it('should handle absence of extra parameter gracefully', () => {
+        const target = new Set<number>();
+        const handlers: SetHandlers<number> = {
+            add: jest.fn().mockReturnValue(true),
+        };
+
+        const proxy = createObservableSet(target, handlers);
+        proxy.add(100);
+
+        expect(handlers.add).toHaveBeenCalledWith(target, 100, undefined);
+        expect(target.has(100)).toBe(true);
+    });
+});

--- a/libraries/aelastics-store/src/common/observableSet.ts
+++ b/libraries/aelastics-store/src/common/observableSet.ts
@@ -1,0 +1,71 @@
+export interface SetHandlers<T, P extends {} = {}> {
+    add?: (target: Set<T>, value: T, extra?: P) => boolean;
+    delete?: (target: Set<T>, value: T, extra?: P) => boolean;
+    clear?: (target: Set<T>, extra?: P) => boolean;
+    has?: (target: Set<T>, value: T, extra?: P) => boolean;
+    forEach?: (target: Set<T>, callback: (value: T, value2: T, set: Set<T>) => void, extra?: P) => boolean;
+    defaultAction?: (target: Set<T>, key: PropertyKey, args?: any[], extra?: P) => boolean;
+}
+
+export function createObservableSet<T, P extends {} = {}>(
+    set: Set<T>,
+    handlers: SetHandlers<T, P>,
+    defaultMutation: boolean = true,
+    extra?: P
+): Set<T> {
+    return new Proxy(set, {
+        get(target: Set<T>, key: string | number | symbol, receiver: any): any {
+            if (typeof key === 'string') {
+                switch (key) {
+                    case 'add':
+                        return (value: T) => {
+                            const allowAdd = handlers.add?.(target, value, extra) ?? defaultMutation;
+                            return allowAdd ? Reflect.apply(target.add, target, [value]) : target;
+                        };
+                    case 'delete':
+                        return (value: T) => {
+                            const allowDelete = handlers.delete?.(target, value, extra) ?? defaultMutation;
+                            return allowDelete ? Reflect.apply(target.delete, target, [value]) : false;
+                        };
+                    case 'clear':
+                        return () => {
+                            const allowClear = handlers.clear?.(target, extra) ?? defaultMutation;
+                            return allowClear ? Reflect.apply(target.clear, target, []) : undefined;
+                        };
+                    case 'has':
+                        return (value: T) => {
+                            const allowHas = handlers.has?.(target, value, extra) ?? defaultMutation;
+                            return allowHas ? Reflect.apply(target.has, target, [value]) : false;
+                        };
+                    case 'forEach':
+                        return (callback: (value: T, value2: T, set: Set<T>) => void) => {
+                            const allowForEach = handlers.forEach?.(target, callback, extra) ?? defaultMutation;
+                            return allowForEach ? Reflect.apply(target.forEach, target, [callback]) : undefined;
+                        };
+                }
+            }
+
+            // Handle property getters like `size`
+            const propDescriptor = Object.getOwnPropertyDescriptor(Set.prototype, key);
+            if (propDescriptor?.get) {
+                if (handlers.defaultAction) {
+                    const allowDefault = handlers.defaultAction(target, key, [], extra);
+                    if (!allowDefault) {
+                        return undefined;
+                    }
+                }
+                return Reflect.get(target, key);
+            }
+
+            // Default behavior for other properties
+            const origProp = Reflect.get(target, key, receiver);
+            if (handlers.defaultAction) {
+                const allowDefault = handlers.defaultAction(target, key, [], extra);
+                if (!allowDefault) {
+                    return undefined;
+                }
+            }
+            return origProp;
+        }
+    });
+}


### PR DESCRIPTION
This PR introduces support for an optional `extra` argument in all observable handlers.

**Changes:**
- Updated `createObservableObject`, `createObservableArray`, `createObservableMap`, and `createObservableSet` to accept an optional extra parameter.
- Modified all relevant handlers to pass this extra context.
- Added Jest test cases to verify that the extra parameter is correctly received.
- Updated documentation to reflect the new feature.

**Closes #30**